### PR TITLE
Add convergence-study example

### DIFF
--- a/doc/bibliography.bib
+++ b/doc/bibliography.bib
@@ -42,3 +42,17 @@
   edition   = {1},
   doi       = {10.1007/3-540-31627-2_3}
 }
+
+@book{Pietro_MathematicalAspectsDG,
+  address   = {Berlin Heidelberg},
+  year      = {2012},
+  issn      = {1154-483X},
+  isbn      = {978-3-642-22979-4},
+  author    = {Di Pietro, Daniele Antonio and Ern, Alexandre},
+  title     = {Mathematical Aspects of Discontinuous Galerkin Methods},
+  volume    = {69},
+  series    = {Mathématiques et Applications},
+  publisher = {Springer-Verlag},
+  doi       = {10.1007/978-3-642-22980-0},
+  url       = {https://hal.archives-ouvertes.fr/hal-01820185}
+}

--- a/doc/pages/coding-conventions.md
+++ b/doc/pages/coding-conventions.md
@@ -419,16 +419,16 @@ list here:
     ```cpp
     std::vector<std::array<unsigned int, 3>>
     sapphirepp::VFP::PDESystem::create_lms_indices(
-      const unsigned int expansion_order)
+      const unsigned int system_size)
     {
       ...
       return lms_indices;
     }
     ```
 
-    Here, the user calls `PDESystem::create_lms_indices(3)`, for example. There
+    Here, the user calls `PDESystem::create_lms_indices(9)`, for example. There
     really is no reason why the function would ever want to change the value of
-    the `expansion_order` argument — so mark it as constant: this both helps the
+    the `system_size` argument — so mark it as constant: this both helps the
     reader of the code understand that this is an input argument of the function
     for which we need not search below whether it is ever changed, and it helps
     the compiler help us find bugs if we ever accidentally change the value.

--- a/doc/pages/examples.md
+++ b/doc/pages/examples.md
@@ -12,6 +12,10 @@
     Serving as a comprehensive guide to @sapphire, this example is highly
     recommended for new developers. It focuses on using scattering to reach a
     solution with diminishing multipoles.
+ 4. @subpage convergence-study  
+    In this advanced example, we derive an analytic solution for the system of
+    equations solved in @sapphire in a special scenario. This is used to verify
+    the accuracy of the numerical methods by performing a convergence study.
 
 
 <div class="section_buttons">

--- a/doc/pages/examples/convergence-study.md
+++ b/doc/pages/examples/convergence-study.md
@@ -1,313 +1,338 @@
 # Advanced example: Convergence study {#convergence-study}
 
+@tableofcontents
 
-## Analytical solution
 
-These are only notes for internal use, we should remove them later.
+## Introduction {#introduction-convergence-study}
 
-We derive an analytic solution for the static `gyro` setup with a truncation at
-$l=1$ using a Fourier transform (FT).
+This example presents a convergence study for @sapphire, utilizing a
+one-dimensional test case with an analytical solution. It also provides an
+overview of advanced features in @sapphire. It is recommended to familiarize
+yourself with @sapphire through the previous examples before starting this one,
+particularly the [quick start](#quick-start) and [scattering
+only](#scattering-only) examples.
 
-The VFP equation is given by:
-
-$$
-  \frac{\partial f}{\partial t} + \mathbf{v} \cdot \nabla_{x} f -
-  q \mathbf{v} \cdot \left( \mathbf{B} \times \nabla_{p} f \right) = 0 \,.
-$$
-
-$$
-  \mathbf{B} = B_0 \hat{\mathbf{e}}_z \,.
-$$
-
-We only work in 1D.
-
-We have two different notations, the @sapphire notation and Brian's.
-
-The expansion of the distribution function is given by:
+We consider a simple one one-dimensional test case with a static magnetic field
+$\mathbf{B} = B_0 \hat{\mathbf{e}}_z$ in a static medium, $\mathbf{u} = 0$.
+Assuming a collisionless plasma, the VFP equation simplifies to:
 
 $$
- f(t, \mathbf{x}, \mathbf{p}) = \sum^{l_{\rm max}}_{l = 0} \sum^{l}_{m = 0}
- \sum^{1}_{s = 0} f_{lms}(t, \mathbf{x}, p) Y_{lms}(\theta,\varphi) \,,
+  \frac{\partial f}{\partial t} + \mathbf{v} \cdot \nabla_{x} f +
+  q \mathbf{v} \cdot \left( \mathbf{B} \times \nabla_{p} f \right) =
+  0\, .
 $$
 
-We get a system of equations:
+Using a cut-off in the spherical harmonic expansion order $l_{\rm max}=1$, the
+system of equations for the expansion coefficients $f_{lms}$ is given by:
 
-$$
-  \partial_{t}\pmb{f} +
-  \left(
-    U^{a}\mathbf{1} +
-    V \mathbf{A}^{a}
-  \right) \partial_{x_{a}}\pmb{f} -
-  \left(
-    \gamma m \frac{\mathrm{d} U_{a}}{\mathrm{d} t} \mathbf{A}^{a} -
-    p \frac{\partial U_{b}}{\partial x^{a}} \mathbf{A}^{a}\mathbf{A}^{b}
-  \right) \partial_{p} \pmb{f} +
-  \left(
-    \frac{1}{V} \epsilon_{abc} \frac{\mathrm{d} U^{a}}{\mathrm{d} t}
-      \mathbf{A}^{b}\mathbf{\Omega}^{c} +
-    \epsilon_{bcd} \frac{\partial U_{b}}{\partial x^{a}}\mathbf{A}^{a}
-      \mathbf{A}^{c}\mathbf{\Omega}^{d}
-  \right) \pmb{f} -
-  \omega_{a}\mathbf{\Omega}^{a}\pmb{f} +
-  \nu \mathbf{C}\pmb{f}
-  = 0
-$$
-
-In our case and with $l_{\rm max}=1$ this simplifies to:
-
-$$
-  \partial_{t}\pmb{f} +
-  V \mathbf{A}^{a} \partial_{x_{a}}\pmb{f} -
-  \omega_{a}\mathbf{\Omega}^{a}\pmb{f}
-  = 0
-$$
-
-Where $\omega_{a} = \omega \delta_{a,z}$, $\omega = \frac{B_0 q}{\gamma m}$.
-In 1D we have $\partial_{x}\pmb{f} = \partial_{z}\pmb{f} = 0$. Therefore:
-
-$$
-  \partial_{t}\pmb{f} +
-  V \mathbf{A}^{x} \partial_{x}\pmb{f} -
-  \omega \mathbf{\Omega}^{z}\pmb{f}
-  = 0
-$$
-
-Putting in the components of $\mathbf{A}$ and $\mathbf{\Omega}$, we get:
-
-$$
-  \partial_{t} f_{000} +
-  \frac{V}{\sqrt{3}} \partial_{x} f_{100}
-  = 0
-$$
-
-$$
-  \partial_{t} f_{110} -
+\begin{align*}
+   & \partial_{t} f_{000} +
+  \frac{v}{\sqrt{3}} \partial_{x} f_{100}
+  = 0                       \\
+   & \partial_{t} f_{110} -
   \omega f_{100}
-  = 0
-$$
-
-$$
-  \partial_{t} f_{100} +
-  \frac{V}{\sqrt{3}} \partial_{x} f_{000} +
+  = 0                       \\
+   & \partial_{t} f_{100} +
+  \frac{v}{\sqrt{3}} \partial_{x} f_{000} +
   \omega f_{110}
-  = 0
-$$
+  = 0 \\
+  & \partial_{t} f_{111} = 0
+\end{align*}
 
-$$
-  \partial_{t} f_{111} = 0
-$$
+Here, we introduced the gyrofrequency $\omega = \frac{B_0 q}{\gamma m}$, with
+the magnetic field $B_0$, the charge $q$, the Lorentz factor $\gamma$, and the
+mass $m$. In the following, we drop $f_{111}$ as it decouples and has a trivial
+solution.
 
-Here, we used
-$A^{x}_{20}=A^{x}_{02}=\sqrt{\frac{(l+m)(l-m)}{(2l+1)(2l-1)}}=1/\sqrt{3}$,
-and $\Omega^{z}_{12} = -\Omega^{z}_{21} = 1$ with all other components
-vanishing.
-Be aware that the ordering of components in the vector is
-$\pmb{f} = (f_{000}, f_{110}, f_{100}, f_{111})$.
+In @cite Schween2024, we derived an analytical solution for this system of
+equations assuming a periodic box of length $L$. We obtained the following
+solution for the expansion coefficients $f_{lms}$:
 
-$f_{111} = \rm const.$ decouples from the system of equations, and we choose the
-initial conditions so that $f_{111} = 0$.
-
-Acting with $\partial_{t}$ on the third equation and inserting the other
-equations, we arrive at:
-
-$$
-  \partial_{t}^2 f_{100} -
-  \frac{V^2}{3} \partial_{x}^2 f_{100} +
-  \omega^2 f_{100}
-  = 0
-$$
-
-We apply the ansatz of factorization for $f_{110}$:
-
-$$
-  f_{100}(t, x) = \phi(t) \psi(x)
-$$
-
-Inserting this into the equation above and denoting
-$\partial_{t} \phi(t) = \dot{\phi}$ and $\partial_{x} \psi(x) = \psi'(x)$,
-we get:
-
-$$
-  \ddot{\phi(t)} \psi(x) -
-  \frac{V^2}{3} \phi(t) \psi''(x) +
-  \omega^2 \phi(t) \psi(x)
-  = 0
-$$
-
-$$
-  \implies
-  \frac{\ddot{\phi(t)} + \omega^2 \phi(t)}{\phi(t)}
-  = \frac{V^2}{3} \frac{\psi''(x)}{\psi(x)}
-  = - c_n^2 = \rm const.
-$$
-
-These equations are respectively solved by:
-
-$$
-  \phi(t) = \phi_{0,n} \sin(\sqrt{\omega^2 + c_n^2} t) +
-    \phi_{1,n} \cos(\sqrt{\omega^2 + c_n^2} t)
-$$
-
-We use initial conditions, such that $f_{100}(t=0) = 0 \implies \phi_{1,n} = 0$.
-
-$$
-  \psi(x) = \psi_{0,n} \sin\left(\frac{\sqrt{3} c_n}{V} x\right) +
-    \psi_{1,n} \cos\left(\frac{\sqrt{3} c_n}{V} x\right)
-$$
-
-The full solution is given by a superposition of these Fourier modes:
-
-$$
-  f_{100}(t, x) = \sum_{n} \phi_{0,n} \sin(\sqrt{\omega^2 + c_n^2} t)
-    \left[ \psi_{0,n} \sin(k_n x) + \psi_{1,n} \cos(k_n x) \right]
-$$
-
-where we introduced the wave number $k_n = \frac{\sqrt{3} c_n}{V}$.
-
-One can notice, that $\phi_{0,n}$, $\psi_{0,n}$ and $\psi_{1,n}$ are degenerate
-once. In the following, we choose $\phi_{0,n} = 1$.
-
-Enforcing periodic boundary conditions in a box with length $L$, we get:
-
-$$
-  k_n L = \frac{\sqrt{3} c_n}{V} L \overset{!}{=} 2 \pi n
-  \implies c_n = \frac{V}{\sqrt{3} L} 2 \pi n \,, k_n = \frac{2 \pi n}{L}
-$$
-
-with $n \in \mathbb{N}$.
-
-Inserting this solution in the equation for $f_{000}$, we get:
-
-$$
-  f_{000}(t,x) - f_{000}(t=0,x)
-  = -\int_{0}^{t} \frac{V}{\sqrt{3}} \partial_{x} f_{100}(\tilde{t}, x)
-    \mathrm{d}\tilde{t}
-  = \sum_{n} \frac{V}{\sqrt{3}} \frac{1}{\sqrt{\omega^2 + c_n^2}}
-    \left[ \cos(\sqrt{\omega^2 + c_n^2} t) - 1 \right] \frac{\sqrt{3} c_n}{V}
-    \left[ \psi_{0,n} \cos(k_n x) - \psi_{1,n} \sin(k_n x) \right]
-$$
-
-We choose the following initial condition for $f_{000}$ (wisely choosing the
-prefactor):
-
-$$
-  f_{000}(t=0, x) = \sum_{n} \sqrt{\omega^2 + c_n^2}
-    \left[ A_n \cos(k_n x) - B_n \sin(k_n x) \right]
-$$
-
-Using this gives us an initial condition for the derivative of $f_{100}$:
-
-$$
-  \partial_{t} f_{100} \rvert_{t=0} +
-  \frac{V}{\sqrt{3}} \partial_{x} f_{000} \rvert_{t=0} +
-  \omega f_{110} \rvert_{t=0}
-  = 0
-$$
-
-Using $f_{110}(t=0,x) = 0$, this results in:
-
-$$
-  \sum_{n} \sqrt{\omega^2 + c_n^2}
-    \left[ \psi_{0,n} \sin(k_n x) + \psi_{1,n} \cos(k_n x) \right]
-  = -\frac{V}{\sqrt{3}} \sum_{n} \sqrt{\omega^2 + c_n^2} k_n
-    \left[ - A_n \sin(k_n x) - B_n \cos(k_n x) \right]
-$$
-
-Comparing the coefficients we get:
-
-$$
-  \psi_{n,0} = \frac{V}{\sqrt{3}} k_n A_n = c_n A_n
-$$
-
-$$
-  \psi_{n,1} = c_n B_n
-$$
-
-We can get $f_{110}$ by integrating $f_{100}$ in time. Using the initial
-condition $f_{110}(t=0) = 0$, we get:
-
-$$
-  f_{110}(t,x) = \int_{0}^{t} \omega f_{100}(\tilde{t}, x) \mathrm{d}\tilde{t}
-  = \sum_{n} \frac{\omega c_n}{\sqrt{\omega^2 + c_n^2}}
-    \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
-    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
-$$
-
-To summarize, we have:
-
-$$
-  f_{000}(t,x) = \sum_{n} \frac{c_n^2}{\sqrt{\omega^2 + c_n^2}}
-    \left[
-      \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
-      \frac{\omega^2 + c_n^2}{c_n^2}
+\begin{align*}
+  f_{000}(t,x)  & = \sum_{n} \frac{c_n^2}{\sqrt{\omega^2 + c_n^2}}
+  \left[
+    \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
+    \frac{\omega^2 + c_n^2}{c_n^2}
     \right]
-    \left[ A_n \cos(k_n x) - B_n \sin(k_n x) \right]
-$$
+  \left[ A_n \cos(k_n x) - B_n \sin(k_n x) \right]                      \\
+  f_{110}(t,x)  & = \sum_{n} \frac{\omega c_n}{\sqrt{\omega^2 + c_n^2}}
+  \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
+  \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]                      \\
+  f_{100}(t, x) & = \sum_{n} c_n \sin(\sqrt{\omega^2 + c_n^2} t)
+  \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
+\end{align*}
+
+$A_n$ and $B_n$ are the Fourier coefficients given by the initial condition for
+$f_{000}$. The wave number $k_n = \frac{2 \pi n}{L}$ and the constant $c_n =
+\frac{v}{\sqrt{3}} k_n$ are determined by the velocity $v$ and the box length $L$.
+
+This analytic solution can be used to compare with the numerical solution at an
+arbitrary time $t$ to assess the convergence of the numerical solution.
+
+
+## Implementation {#implementation-convergence-study}
+
+In the following, we will show the implementation of the convergence study
+example in @sapphire. As always, the steup is devided up into two main files:
+
+- [config.h](#config-convergence-study) which defines the setup of the VFP
+  system and runtime parameters.
+- [convergence-study.cpp](#main-convergence-study) which implements the `main`
+  function to executes the simulation and compares the result to the analytic
+  solution.
+
+In this example, we will only highlight the main parts of the implementation.
+For a comprehensive overview, please refer to the [scattering
+only](#scattering-only) example.
+
+
+### config.h {#config-convergence-study}
+
+
+#### VFP equation {#dimension-convergence-study}
+
+Given that the example considers a one-dimensional problem with decoupling of
+the momenta, we can set the dimensionality of the problem to `dim = dim_ps =
+dim_cs = 2`.
+
+@snippet{lineno} examples/convergence-study/config.h Dimension
+
+In the VFP equation, we only have the @ref sapphirepp::VFP::VFPFlags::magnetic
+"magnetic", $q \mathbf{v} \cdot \left( \mathbf{B} \times \nabla_{p} f \right)$,
+and @ref sapphirepp::VFP::VFPFlags::spatial_advection "spatial advection",
+$(\mathbf{u} + \mathbf{v}) \cdot \nabla_{x} f$, terms. For the latter, we are in
+the spatial case of a static background plasma, $\mathbf{u} = 0$. The magnetic
+field is time independent, hence we can use
+@ref sapphirepp::VFP::VFPFlags::time_independent_fields "time independent" flag.
+
+@snippet{lineno} examples/convergence-study/config.h VFP Flags
+
+
+#### Runtime Parameters {#parameter-convergence-study}
+
+The main parameters describing out setup are the magnetic field strength $B_0$,
+and the box length $L$. For simplicity, we hardcode the coefficients $A_n$ and
+$B_n$ for the initial conditions. We leave the implementation of these as
+runtime parameters as an exercise for the interested reader.
+
+One peculiarity is, that the box length $L$ is already given by the domain size
+defined in the @ref sapphirepp::VFP::VFPParameters "VFPParameters" class.
+However, in order to access this parameter in the @ref
+sapphirepp::VFP::InitialValueFunction "InitialValueFunction", we need to copy it
+to the @ref sapphirepp::PhysicalParameters "PhysicalParameters" class. The same
+goes for the velocity $v$, gamma factor $\gamma$, charge $q$, and mass $m$.
+
+1. **Define**
+
+   We start by defining the runtime parameters, including a copy of the @ref
+   sapphirepp::VFP::VFPParameters "VFPParameters" $L$, $v$, $\gamma$, $q$, and
+   $m$. We will copy their values in the [main
+   function](#setup-convergence-study).
+
+   @snippet{lineno} examples/convergence-study/config.h Define runtime parameter
+
+2. **Declare**
+  
+   As in the [gyro-advection](#gyro-advection) example, we use the trick to use
+   $\frac{B_0}{2 \pi}$ instead of $B_0$ as an input parameter. Since the main
+   frequency in the problem is the gyrofrequency $\omega = \frac{B_0 q}{\gamma
+    m}$, we want to ensure that a final time $T_{\rm final} = n \times T_g = n
+    \times \frac{2 \pi}{B_0} \frac{\gamma m}{q}$ corresponds to exactly $n$ full
+   gyroperiods.
+
+   @snippet{lineno} examples/convergence-study/config.h Declare runtime parameter
+
+3. **Parse**
+
+   Last, we parse the runtime parameter $B_0$:
+
+   @snippet{lineno} examples/convergence-study/config.h Parse runtime parameter
+
+
+#### Analytic solution {#initial-condition-convergence-study}
+
+We "misuse" the @ref sapphirepp::VFP::InitialValueFunction
+"InitialValueFunction" to implement the analytic solution at all times. Setting
+$t=0$ yields the initial condition, but setting $t>0$ yields the analytic
+solution at a given time. To recall the analytic solution, we have:
+
+
+\begin{align*}
+  f_{000}(t,x)  & = \sum_{n} \frac{c_n^2}{\sqrt{\omega^2 + c_n^2}}
+  \left[
+    \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
+    \frac{\omega^2 + c_n^2}{c_n^2}
+    \right]
+  \left[ A_n \cos(k_n x) - B_n \sin(k_n x) \right]                      \\
+  f_{110}(t,x)  & = \sum_{n} \frac{\omega c_n}{\sqrt{\omega^2 + c_n^2}}
+  \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
+  \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]                      \\
+  f_{100}(t, x) & = \sum_{n} c_n \sin(\sqrt{\omega^2 + c_n^2} t)
+  \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
+\end{align*}
+
+with  $\omega = \frac{B_0 q}{\gamma m}$, $k_n = \frac{2 \pi n}{L}$ and $c_n =
+\frac{v}{\sqrt{3}} k_n$. As mentioned before, we hardcode the coefficients $A_n$ and
+$B_n$ for simplicity. We choose a simple sin wave $B_1 = 1$. To ensure
+positivity of the analytic solution, we use the offset $A_0 = 2$.
+
+We start the implementation by defining some useful constants. To access the
+current time, we use the
+@dealref{get_time(),classFunctionTime,ae7d37ddb04314b38cf67c6cba22923f6} method
+of the @dealref{dealii::Function,classFunction} class. We define the
+coefficients $A_n$ and $B_n$ as array, containing `A[0] = A_0`, `A[1] = A_1`,
+etc.
+
+@snippet{lineno} examples/convergence-study/config.h Initial value constants
+
+Now, we implement the solution by looping over the modes $n=0$ until $n_{\rm
+max}$. Note that we took special care in the $f_{000}$ term to avoid division by
+$c_n$, which evaluates to zero for $n=0$.
+
+@snippet{lineno} examples/convergence-study/config.h Initial value
+
+
+#### Magnetic field {#magnetic-field-convergence-study}
+
+The implementation of the magnetic field $\mathbf{B} = B_0 \hat{\mathbf{e}}_z$
+is straightforward:f
+
+@snippet{lineno} examples/convergence-study/config.h Magnetic field
+
+
+### convergence-study.cpp {#main-convergence-study}
+
+In the `main` function, we will implement the comparison of the numerical and
+analytic solution. Because we want to compare the solution at all time steps, we
+will not use the @ref sapphirepp::VFP::VFPSolver::run "run()" function, but
+implement the time loop ourselves. We will also output add the analytic solution
+to the output, showing a comparison between `projection` and `interpolation` of
+the solution (see the [visualization](#visualization) section).
+
+
+#### Setup {#setup-convergence-study}
+
+The setup in the main function is fairly standard. We initialize MPI, and the
+@ref sapphirepp::saplog "saplog" stream. We then parse the runtime parameters.
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Main function setup
+
+One speciality is that we need to copy the runtime parameters $L$, $v$,
+$\gamma$, $q$, and $m$ to the @ref sapphirepp::PhysicalParameters
+"PhysicalParameters" class. In addition, we check if the assumptions of $l_{\rm
+max} = 1$ and periodic boundary conditions are met.
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Copy VFP parameter
+
+As we want to calculate the numerical error at every time step, we create a
+`csv` file to store the results.
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Create error file
+
+Now we create and set up the @ref sapphirepp::VFP::VFPSolver "VFPSolver" object.
+Notice that we are not using the @ref sapphirepp::VFP::VFPSolver::run "run()"
+function, but implement the time loop ourselves.
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Setup vfp_solver
+
+Last, we have to prepare the analytic solution. To this end create an instance
+of the @ref sapphirepp::VFP::InitialValueFunction "InitialValueFunction" and a
+@dealref{Vector,classPETScWrappers_1_1MPI_1_1Vector}. In addition, we create a
+@dealref{ComponentSelectFunction} in order to on;y compare the $f_{000}$ modes
+when calculating the error.
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Setup analytic solution
+
+
+#### Time loop {#time-loop-convergence-study}
+
+Next comes the integral part of the simulation: the time loop. Every time step
+we have to perform the following steps:
+
+- Output the solution, numeric and analytic
+- Calculate the error
+- Advance the time, by performing an Euler or Runge-Kutta step
+
+To keep track of the time steps, we use the @dealref{DiscreteTime} class.
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Time loop
+
+We only want to output the solution every Nth time steps, where N is the
+`output_frequency`. Ensuring this with an `if` statement, we add three
+different vectors to the output:
+
+- the numeric solution
+- a projection of analytic solution onto the finite element DG space
+- an interpolation of the analytic solution
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Output solution
+
+Next we calculate the error and the norm of the solution. Notice that the
+`weight` function allows us to only select the $f_{000}$ mode. Having both the
+$L^2$ error, $\lVert f_{000, h}^{n} - f_{000}(t^n) \rVert_{L^2}$, and the $L^2$
+norm, $\lVert f_{000, h}^{n} \rVert_{L^2}$, we can calculate the relative error
+as
 
 $$
-  f_{110}(t,x) = \sum_{n} \frac{\omega c_n}{\sqrt{\omega^2 + c_n^2}}
-    \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
-    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
+  \text{rel. error} \coloneqq \frac{\lVert f_{000, h}^{n} - f_{000}(t^n)
+  \rVert_{L^2}}{\lVert f_{000, h}^{n} \rVert_{L^2}} \,.
 $$
 
-$$
-  f_{100}(t, x) = \sum_{n} c_n \sin(\sqrt{\omega^2 + c_n^2} t)
-    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
-$$
+We output this results and save them to the `csv` file.
 
-$$
-  f_{111}(t, x) = 0
-$$
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Calculate error
+
+Finally, we advance the time by performing an Euler or Runge-Kutta step. We
+select the method according to the `time_stepping_method` runtime parameter, and
+use the methods implemented in the @ref sapphirepp::VFP::VFPSolver "VFPSolver".
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Time step
+
+
+#### End simulation {#end-simulation-convergence-study}
+
+After finishing the time loop, we output the final results, and calculate the
+final error.
+
+@note In @sapphire, we output the results at the *start* of each time step.
+  Therefore, we additionally need to output the final results after the last
+  time step.
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp Last time step
+
+Finally, we can end the simulation and close the `csv` file.
+
+@snippet{lineno} examples/convergence-study/convergence-study.cpp End simulation
+
+
+## Results {#results-convergence-study}
+
+@todo Add results for convergence study example.
+
+
+## The plain program {#plain-convergence-study}
+
+
+### config.h {#plain-config-convergence-study}
+
+@include{lineno} examples/convergence-study/config.h
+
+
+### convergence-study.cpp {#plain-main-convergence-study}
+
+@include{lineno} examples/convergence-study/convergence-study.cpp
+
+
+<div class="section_buttons">
+
+| Previous              |
+|:----------------------|
+| [Examples](#examples) |
+
+</div>
 
 
 ---
 
-Last, we check again, that this solution is correct by inserting it into the
-third equation of the system of equations:
-
-$$
-  \partial_{t} f_{100} +
-  \frac{V}{\sqrt{3}} \partial_{x} f_{000} +
-  \omega f_{110}
-  = 0
-$$
-
-Inserting all functions we arrive at:
-
-$$
-  \sum_{n} c_n \sqrt{\omega^2 + c_n^2} \cos(\sqrt{\omega^2 + c_n^2} t)
-    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right] +
-  \sum_{n} \frac{V}{\sqrt{3}}\frac{c_n^2}{\sqrt{\omega^2 + c_n^2}}
-    \left[
-      \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
-      \frac{\omega^2 + c_n^2}{c_n^2}
-    \right]
-    k_n \left[ -A_n \sin(k_n x) - B_n \cos(k_n x) \right] +
-  \sum_{n} \frac{\omega^2 c_n}{\sqrt{\omega^2 + c_n^2}}
-    \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
-    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
-  = 0
-$$
-
-Comparing the coefficients we have:
-
-$$
-  c_n \sqrt{\omega^2 + c_n^2} \cos(\sqrt{\omega^2 + c_n^2} t) -
-  \frac{c_n^3}{\sqrt{\omega^2 + c_n^2}}
-    \left[
-      \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
-      \frac{\omega^2 + c_n^2}{c_n^2}
-    \right] +
-  \frac{\omega^2 c_n}{\sqrt{\omega^2 + c_n^2}}
-    \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
-  = 0
-$$
-
-$$
-  \implies
-  \left[
-    \omega^2 + c_n^2 - c_n^2 - \omega^2
-  \right] \cos(\sqrt{\omega^2 + c_n^2} t) +
-  c_n^2 - (\omega^2 + c_n^2) + \omega^2
-  = 0 \quad \rm (correct)
-$$
+@author Florian Schulze (<florian.schulze@mpi-hd.mpg.de>)
+@date 2024-03-07

--- a/doc/pages/examples/convergence-study.md
+++ b/doc/pages/examples/convergence-study.md
@@ -1,0 +1,313 @@
+# Advanced example: Convergence study {#convergence-study}
+
+
+## Analytical solution
+
+These are only notes for internal use, we should remove them later.
+
+We derive an analytic solution for the static `gyro` setup with a truncation at
+$l=1$ using a Fourier transform (FT).
+
+The VFP equation is given by:
+
+$$
+  \frac{\partial f}{\partial t} + \mathbf{v} \cdot \nabla_{x} f -
+  q \mathbf{v} \cdot \left( \mathbf{B} \times \nabla_{p} f \right) = 0 \,.
+$$
+
+$$
+  \mathbf{B} = B_0 \hat{\mathbf{e}}_z \,.
+$$
+
+We only work in 1D.
+
+We have two different notations, the @sapphire notation and Brian's.
+
+The expansion of the distribution function is given by:
+
+$$
+ f(t, \mathbf{x}, \mathbf{p}) = \sum^{l_{\rm max}}_{l = 0} \sum^{l}_{m = 0}
+ \sum^{1}_{s = 0} f_{lms}(t, \mathbf{x}, p) Y_{lms}(\theta,\varphi) \,,
+$$
+
+We get a system of equations:
+
+$$
+  \partial_{t}\pmb{f} +
+  \left(
+    U^{a}\mathbf{1} +
+    V \mathbf{A}^{a}
+  \right) \partial_{x_{a}}\pmb{f} -
+  \left(
+    \gamma m \frac{\mathrm{d} U_{a}}{\mathrm{d} t} \mathbf{A}^{a} -
+    p \frac{\partial U_{b}}{\partial x^{a}} \mathbf{A}^{a}\mathbf{A}^{b}
+  \right) \partial_{p} \pmb{f} +
+  \left(
+    \frac{1}{V} \epsilon_{abc} \frac{\mathrm{d} U^{a}}{\mathrm{d} t}
+      \mathbf{A}^{b}\mathbf{\Omega}^{c} +
+    \epsilon_{bcd} \frac{\partial U_{b}}{\partial x^{a}}\mathbf{A}^{a}
+      \mathbf{A}^{c}\mathbf{\Omega}^{d}
+  \right) \pmb{f} -
+  \omega_{a}\mathbf{\Omega}^{a}\pmb{f} +
+  \nu \mathbf{C}\pmb{f}
+  = 0
+$$
+
+In our case and with $l_{\rm max}=1$ this simplifies to:
+
+$$
+  \partial_{t}\pmb{f} +
+  V \mathbf{A}^{a} \partial_{x_{a}}\pmb{f} -
+  \omega_{a}\mathbf{\Omega}^{a}\pmb{f}
+  = 0
+$$
+
+Where $\omega_{a} = \omega \delta_{a,z}$, $\omega = \frac{B_0 q}{\gamma m}$.
+In 1D we have $\partial_{x}\pmb{f} = \partial_{z}\pmb{f} = 0$. Therefore:
+
+$$
+  \partial_{t}\pmb{f} +
+  V \mathbf{A}^{x} \partial_{x}\pmb{f} -
+  \omega \mathbf{\Omega}^{z}\pmb{f}
+  = 0
+$$
+
+Putting in the components of $\mathbf{A}$ and $\mathbf{\Omega}$, we get:
+
+$$
+  \partial_{t} f_{000} +
+  \frac{V}{\sqrt{3}} \partial_{x} f_{100}
+  = 0
+$$
+
+$$
+  \partial_{t} f_{110} -
+  \omega f_{100}
+  = 0
+$$
+
+$$
+  \partial_{t} f_{100} +
+  \frac{V}{\sqrt{3}} \partial_{x} f_{000} +
+  \omega f_{110}
+  = 0
+$$
+
+$$
+  \partial_{t} f_{111} = 0
+$$
+
+Here, we used
+$A^{x}_{20}=A^{x}_{02}=\sqrt{\frac{(l+m)(l-m)}{(2l+1)(2l-1)}}=1/\sqrt{3}$,
+and $\Omega^{z}_{12} = -\Omega^{z}_{21} = 1$ with all other components
+vanishing.
+Be aware that the ordering of components in the vector is
+$\pmb{f} = (f_{000}, f_{110}, f_{100}, f_{111})$.
+
+$f_{111} = \rm const.$ decouples from the system of equations, and we choose the
+initial conditions so that $f_{111} = 0$.
+
+Acting with $\partial_{t}$ on the third equation and inserting the other
+equations, we arrive at:
+
+$$
+  \partial_{t}^2 f_{100} -
+  \frac{V^2}{3} \partial_{x}^2 f_{100} +
+  \omega^2 f_{100}
+  = 0
+$$
+
+We apply the ansatz of factorization for $f_{110}$:
+
+$$
+  f_{100}(t, x) = \phi(t) \psi(x)
+$$
+
+Inserting this into the equation above and denoting
+$\partial_{t} \phi(t) = \dot{\phi}$ and $\partial_{x} \psi(x) = \psi'(x)$,
+we get:
+
+$$
+  \ddot{\phi(t)} \psi(x) -
+  \frac{V^2}{3} \phi(t) \psi''(x) +
+  \omega^2 \phi(t) \psi(x)
+  = 0
+$$
+
+$$
+  \implies
+  \frac{\ddot{\phi(t)} + \omega^2 \phi(t)}{\phi(t)}
+  = \frac{V^2}{3} \frac{\psi''(x)}{\psi(x)}
+  = - c_n^2 = \rm const.
+$$
+
+These equations are respectively solved by:
+
+$$
+  \phi(t) = \phi_{0,n} \sin(\sqrt{\omega^2 + c_n^2} t) +
+    \phi_{1,n} \cos(\sqrt{\omega^2 + c_n^2} t)
+$$
+
+We use initial conditions, such that $f_{100}(t=0) = 0 \implies \phi_{1,n} = 0$.
+
+$$
+  \psi(x) = \psi_{0,n} \sin\left(\frac{\sqrt{3} c_n}{V} x\right) +
+    \psi_{1,n} \cos\left(\frac{\sqrt{3} c_n}{V} x\right)
+$$
+
+The full solution is given by a superposition of these Fourier modes:
+
+$$
+  f_{100}(t, x) = \sum_{n} \phi_{0,n} \sin(\sqrt{\omega^2 + c_n^2} t)
+    \left[ \psi_{0,n} \sin(k_n x) + \psi_{1,n} \cos(k_n x) \right]
+$$
+
+where we introduced the wave number $k_n = \frac{\sqrt{3} c_n}{V}$.
+
+One can notice, that $\phi_{0,n}$, $\psi_{0,n}$ and $\psi_{1,n}$ are degenerate
+once. In the following, we choose $\phi_{0,n} = 1$.
+
+Enforcing periodic boundary conditions in a box with length $L$, we get:
+
+$$
+  k_n L = \frac{\sqrt{3} c_n}{V} L \overset{!}{=} 2 \pi n
+  \implies c_n = \frac{V}{\sqrt{3} L} 2 \pi n \,, k_n = \frac{2 \pi n}{L}
+$$
+
+with $n \in \mathbb{N}$.
+
+Inserting this solution in the equation for $f_{000}$, we get:
+
+$$
+  f_{000}(t,x) - f_{000}(t=0,x)
+  = -\int_{0}^{t} \frac{V}{\sqrt{3}} \partial_{x} f_{100}(\tilde{t}, x)
+    \mathrm{d}\tilde{t}
+  = \sum_{n} \frac{V}{\sqrt{3}} \frac{1}{\sqrt{\omega^2 + c_n^2}}
+    \left[ \cos(\sqrt{\omega^2 + c_n^2} t) - 1 \right] \frac{\sqrt{3} c_n}{V}
+    \left[ \psi_{0,n} \cos(k_n x) - \psi_{1,n} \sin(k_n x) \right]
+$$
+
+We choose the following initial condition for $f_{000}$ (wisely choosing the
+prefactor):
+
+$$
+  f_{000}(t=0, x) = \sum_{n} \frac{\sqrt{\omega^2 + c_n^2}}{c_n}
+    \left[ A_n \cos(k_n x) - B_n \sin(k_n x) \right]
+$$
+
+Using this gives us an initial condition for the derivative of $f_{100}$:
+
+$$
+  \partial_{t} f_{100} \rvert_{t=0} +
+  \frac{V}{\sqrt{3}} \partial_{x} f_{000} \rvert_{t=0} +
+  \omega f_{110} \rvert_{t=0}
+  = 0
+$$
+
+Using $f_{110}(t=0,x) = 0$, this results in:
+
+$$
+  \sum_{n} \sqrt{\omega^2 + c_n^2}
+    \left[ \psi_{0,n} \sin(k_n x) + \psi_{1,n} \cos(k_n x) \right]
+  = -\frac{V}{\sqrt{3}} \sum_{n} \frac{\sqrt{\omega^2 + c_n^2}}{c_n} k_n
+    \left[ - A_n \sin(k_n x) - B_n \cos(k_n x) \right]
+$$
+
+Comparing the coefficients we get:
+
+$$
+  \psi_{n,0} = \frac{V}{\sqrt{3}} \frac{k_n A_n}{c_n} = A_n
+$$
+
+$$
+  \psi_{n,1} = B_n
+$$
+
+We can get $f_{110}$ by integrating $f_{100}$ in time. Using the initial
+condition $f_{110}(t=0) = 0$, we get:
+
+$$
+  f_{110}(t,x) = \int_{0}^{t} \omega f_{100}(\tilde{t}, x) \mathrm{d}\tilde{t}
+  = \sum_{n} \frac{\omega}{\sqrt{\omega^2 + c_n^2}}
+    \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
+    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
+$$
+
+To summarize, we have:
+
+$$
+  f_{000}(t,x) = \sum_{n} \frac{c_n}{\sqrt{\omega^2 + c_n^2}}
+    \left[
+      \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
+      \frac{\omega^2 + c_n^2}{c_n^2}
+    \right]
+    \left[ A_n \cos(k_n x) - B_n \sin(k_n x) \right]
+$$
+
+$$
+  f_{110}(t,x) = \sum_{n} \frac{\omega}{\sqrt{\omega^2 + c_n^2}}
+    \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
+    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
+$$
+
+$$
+  f_{100}(t, x) = \sum_{n} \sin(\sqrt{\omega^2 + c_n^2} t)
+    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
+$$
+
+$$
+  f_{111}(t, x) = 0
+$$
+
+
+---
+
+Last, we check again, that this solution is correct by inserting it into the
+third equation of the system of equations:
+
+$$
+  \partial_{t} f_{100} +
+  \frac{V}{\sqrt{3}} \partial_{x} f_{000} +
+  \omega f_{110}
+  = 0
+$$
+
+Inserting all functions we arrive at:
+
+$$
+  \sum_{n} \sqrt{\omega^2 + c_n^2} \cos(\sqrt{\omega^2 + c_n^2} t)
+    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right] +
+  \sum_{n} \frac{V}{\sqrt{3}}\frac{c_n}{\sqrt{\omega^2 + c_n^2}}
+    \left[
+      \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
+      \frac{\omega^2 + c_n^2}{c_n^2}
+    \right]
+    k_n \left[ -A_n \sin(k_n x) - B_n \cos(k_n x) \right] +
+  \sum_{n} \frac{\omega^2}{\sqrt{\omega^2 + c_n^2}}
+    \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
+    \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
+  = 0
+$$
+
+Comparing the coefficients we have:
+
+$$
+  \sqrt{\omega^2 + c_n^2} \cos(\sqrt{\omega^2 + c_n^2} t) -
+  \frac{c_n^2}{\sqrt{\omega^2 + c_n^2}}
+    \left[
+      \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
+      \frac{\omega^2 + c_n^2}{c_n^2}
+    \right] +
+  \frac{\omega^2}{\sqrt{\omega^2 + c_n^2}}
+    \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
+  = 0
+$$
+
+$$
+  \implies
+  \left[
+    \omega^2 + c_n^2 - c_n^2 - \omega^2
+  \right] \cos(\sqrt{\omega^2 + c_n^2} t) +
+  c_n^2 - (\omega^2 + c_n^2) + \omega^2
+  = 0 \quad \rm (correct)
+$$

--- a/doc/pages/examples/convergence-study.md
+++ b/doc/pages/examples/convergence-study.md
@@ -191,7 +191,7 @@ We choose the following initial condition for $f_{000}$ (wisely choosing the
 prefactor):
 
 $$
-  f_{000}(t=0, x) = \sum_{n} \frac{\sqrt{\omega^2 + c_n^2}}{c_n}
+  f_{000}(t=0, x) = \sum_{n} \sqrt{\omega^2 + c_n^2}
     \left[ A_n \cos(k_n x) - B_n \sin(k_n x) \right]
 $$
 
@@ -209,18 +209,18 @@ Using $f_{110}(t=0,x) = 0$, this results in:
 $$
   \sum_{n} \sqrt{\omega^2 + c_n^2}
     \left[ \psi_{0,n} \sin(k_n x) + \psi_{1,n} \cos(k_n x) \right]
-  = -\frac{V}{\sqrt{3}} \sum_{n} \frac{\sqrt{\omega^2 + c_n^2}}{c_n} k_n
+  = -\frac{V}{\sqrt{3}} \sum_{n} \sqrt{\omega^2 + c_n^2} k_n
     \left[ - A_n \sin(k_n x) - B_n \cos(k_n x) \right]
 $$
 
 Comparing the coefficients we get:
 
 $$
-  \psi_{n,0} = \frac{V}{\sqrt{3}} \frac{k_n A_n}{c_n} = A_n
+  \psi_{n,0} = \frac{V}{\sqrt{3}} k_n A_n = c_n A_n
 $$
 
 $$
-  \psi_{n,1} = B_n
+  \psi_{n,1} = c_n B_n
 $$
 
 We can get $f_{110}$ by integrating $f_{100}$ in time. Using the initial
@@ -228,7 +228,7 @@ condition $f_{110}(t=0) = 0$, we get:
 
 $$
   f_{110}(t,x) = \int_{0}^{t} \omega f_{100}(\tilde{t}, x) \mathrm{d}\tilde{t}
-  = \sum_{n} \frac{\omega}{\sqrt{\omega^2 + c_n^2}}
+  = \sum_{n} \frac{\omega c_n}{\sqrt{\omega^2 + c_n^2}}
     \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
     \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
 $$
@@ -236,7 +236,7 @@ $$
 To summarize, we have:
 
 $$
-  f_{000}(t,x) = \sum_{n} \frac{c_n}{\sqrt{\omega^2 + c_n^2}}
+  f_{000}(t,x) = \sum_{n} \frac{c_n^2}{\sqrt{\omega^2 + c_n^2}}
     \left[
       \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
       \frac{\omega^2 + c_n^2}{c_n^2}
@@ -245,13 +245,13 @@ $$
 $$
 
 $$
-  f_{110}(t,x) = \sum_{n} \frac{\omega}{\sqrt{\omega^2 + c_n^2}}
+  f_{110}(t,x) = \sum_{n} \frac{\omega c_n}{\sqrt{\omega^2 + c_n^2}}
     \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
     \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
 $$
 
 $$
-  f_{100}(t, x) = \sum_{n} \sin(\sqrt{\omega^2 + c_n^2} t)
+  f_{100}(t, x) = \sum_{n} c_n \sin(\sqrt{\omega^2 + c_n^2} t)
     \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
 $$
 
@@ -275,15 +275,15 @@ $$
 Inserting all functions we arrive at:
 
 $$
-  \sum_{n} \sqrt{\omega^2 + c_n^2} \cos(\sqrt{\omega^2 + c_n^2} t)
+  \sum_{n} c_n \sqrt{\omega^2 + c_n^2} \cos(\sqrt{\omega^2 + c_n^2} t)
     \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right] +
-  \sum_{n} \frac{V}{\sqrt{3}}\frac{c_n}{\sqrt{\omega^2 + c_n^2}}
+  \sum_{n} \frac{V}{\sqrt{3}}\frac{c_n^2}{\sqrt{\omega^2 + c_n^2}}
     \left[
       \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
       \frac{\omega^2 + c_n^2}{c_n^2}
     \right]
     k_n \left[ -A_n \sin(k_n x) - B_n \cos(k_n x) \right] +
-  \sum_{n} \frac{\omega^2}{\sqrt{\omega^2 + c_n^2}}
+  \sum_{n} \frac{\omega^2 c_n}{\sqrt{\omega^2 + c_n^2}}
     \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
     \left[ A_n \sin(k_n x) + B_n \cos(k_n x) \right]
   = 0
@@ -292,13 +292,13 @@ $$
 Comparing the coefficients we have:
 
 $$
-  \sqrt{\omega^2 + c_n^2} \cos(\sqrt{\omega^2 + c_n^2} t) -
-  \frac{c_n^2}{\sqrt{\omega^2 + c_n^2}}
+  c_n \sqrt{\omega^2 + c_n^2} \cos(\sqrt{\omega^2 + c_n^2} t) -
+  \frac{c_n^3}{\sqrt{\omega^2 + c_n^2}}
     \left[
       \cos(\sqrt{\omega^2 + c_n^2} t) - 1 +
       \frac{\omega^2 + c_n^2}{c_n^2}
     \right] +
-  \frac{\omega^2}{\sqrt{\omega^2 + c_n^2}}
+  \frac{\omega^2 c_n}{\sqrt{\omega^2 + c_n^2}}
     \left[ 1 - \cos(\sqrt{\omega^2 + c_n^2} t) \right]
   = 0
 $$

--- a/doc/pages/examples/convergence-study.md
+++ b/doc/pages/examples/convergence-study.md
@@ -274,7 +274,7 @@ norm, $\lVert f_{000, h}^{n} \rVert_{L^2}$, we can calculate the relative error
 as
 
 $$
-  \text{rel. error} \coloneqq \frac{\lVert f_{000, h}^{n} - f_{000}(t^n)
+  \text{rel. error} := \frac{\lVert f_{000, h}^{n} - f_{000}(t^n)
   \rVert_{L^2}}{\lVert f_{000, h}^{n} \rVert_{L^2}} \,.
 $$
 
@@ -307,7 +307,30 @@ Finally, we can end the simulation and close the `csv` file.
 
 ## Results {#results-convergence-study}
 
-@todo Add results for convergence study example.
+Showing the results for a low resolution run, illustrates the difference between
+*projection* and *interpolation* of the analytic solution. While the
+interpolation gives the exact values at the nodes, the projection approximates
+the solution in the finite element space. Using a discontinuous Galerkin method,
+the projection is not continuous, but has jumps at the nodes. We can see that
+the *weak* numerical solution is approximating the *projection* of the analytic
+solution. Consequently, the numeric solution is not continuous and shows jumps
+at the nodes. We discuss this in more detail in the
+[visualization](#visualization) section.
+
+![Results t0](https://sapphirepp.org/img/examples/convergence-study/convergence_study_t0.png)
+![Results tEnd](https://sapphirepp.org/img/examples/convergence-study/convergence_study_tEnd.png)
+
+Running the simulation for different time steps, $\Delta t$, we can assess the
+convergence of the numerical solution. As expected, the `ERK4` method is forth
+order, while the forward Euler method is only first order. We can also study the
+convergence of the numerical solution with spatial resolutions $\Delta
+x$ for different polynomial degrees $k$. In this case, we expect the error to
+follow a $(\Delta x)^{k+1}$ scaling, assuming the projection error dominates.
+
+<p float="center">
+  <img src="https://sapphirepp.org/img/examples/convergence-study/convergence_study_dt.png" alt="Convergence dt" width="49%">
+  <img src="https://sapphirepp.org/img/examples/convergence-study/convergence_study_dx.png" alt="Convergence dx" width="49%">
+</p>
 
 
 ## The plain program {#plain-convergence-study}

--- a/doc/pages/examples/scattering-only.md
+++ b/doc/pages/examples/scattering-only.md
@@ -164,8 +164,8 @@ class. We create the class @ref sapphirepp::VFP::InitialValueFunction
 @dealref{Function}. In line with the @dealii style, we keep the dimension as a
 template parameter, even though it is defined in the compile-time variable
 `dimension`. This function needs to provide a value for each component
-$f_{lms}$, making it a **vector-valued** function with $(l_{\rm max}+1)^2$
-components.
+$f_{lms}$, making it a **vector-valued** function with `system_size =
+(l_max+1)^2` components.
 
 In the constructor, we pass the @ref sapphirepp::PhysicalParameters
 "PhysicalParameters" and store it in the `private const` variable `prm`. This
@@ -185,7 +185,7 @@ component $f_{lms}$ at the given point, which is stored in the results vector
 `f`.
 
 To catch implementation errors, we check that the size of the results vector `f`
-matches the number of components $(l_{\rm max}+1)^2$, using the
+matches the number of components `system_size`, using the
 @dealref{Assert,group__Exceptions,ga70a0bb353656e704acf927945277bbc6} macro,
 which is only activated in debug mode. Note that we use
 `static_cast<void>(point)` to avoid a compiler warning about an unused variable.

--- a/doc/pages/examples/scattering-only.md
+++ b/doc/pages/examples/scattering-only.md
@@ -455,19 +455,19 @@ create a @dealref{MPI::Vector,classPETScWrappers_1_1MPI_1_1Vector} object. We
 store the finite element coefficients of the analytic solution in this vector
 using the
 @dealref{interpolate(),namespaceVectorTools,a32b68e11070496fcaf6c2389f088d09c}
-function.
+function. Note that the interpolation ensures that the values at the nodes are
+given by the function values. This is not the case for a projected function,
+which the weak solution approximates. We refer to the discussion in the
+[visualization](#visualization) section.
 
 @snippet{lineno} examples/scattering-only/scattering-only.cpp Calculate analytic solution
 
-In order to assign names to the components of the vector, we create a list
-called `component_names`. This list maps each component index to its
-corresponding name.
-
-@snippet{lineno} examples/scattering-only/scattering-only.cpp Component names
-
 Finally, we write the analytic solution to a file using the @dealref{DataOut}
 object and the @ref sapphirepp::Utils::OutputParameters::write_results
-"write_results()" function.
+"write_results()" function. We can make use of the @ref
+sapphirepp::VFP::PDESystem::create_component_name_list
+"create_component_name_list()" function to name the components of the
+vector.
 
 @snippet{lineno} examples/scattering-only/scattering-only.cpp Output analytic solution
 

--- a/doc/pages/visualization.md
+++ b/doc/pages/visualization.md
@@ -2,45 +2,122 @@
 
 @tableofcontents
 
-@todo So far these are only notes. They need to be reworked.
+Working with discontinuous Galerkin (DG) finite element methods can be
+counterintuitive when it comes to visualizing and interpreting the results. As
+the name suggests, the solution is multivalued and discontinuous at cell edges,
+a feature which contrasts the nature of Finite Difference (FD) or Finite Volume
+(FV) methods. These methods by definition only have one value per node/cell. In
+this section, we want to provide you some tips, tricks and lessons we had to
+learn on the way, that might help with visualizing and interpreting the output
+of @sapphire.
 
-Here are some tips and tricks for visualizing the output of @sapphire. We also
-give some advice how to interpret the output.
+
+## Discontinuous Galerkin Finite Elements: Projection vs. Interpolation {#dg-fe-visualization}
+
+In finite element (FE) methods, differential equation are solved by finding
+*weak* solutions to the problem. This means, that the numeric solution $f_h(x)$
+does not need to converge to the full solution $f$ point wise, but only in the
+integral sense. We express this in the following way:
+
+$$
+  (f, v) = (f_h, v) \quad \forall v \in V_h \,,
+$$
+
+where $v$ is a test function and $(f, v) = \int f(x) v(x) dx$ is the inner
+product of the function space $V_h$. Using that $V_h$ is spanned by a set of
+basis functions $\phi_i(x)$, Galerkin methods use them to project the solution
+$f_h$ into the function space $V_h$:
+
+$$
+  f_h(x) = \sum_i f_i \phi_i(x) \,.
+$$
+
+The numeric solution is now represented by the coefficients $f_i$. We say that
+$f_h(x)$ is the *projection* of $f(x)$ onto the FE space. In the picture below
+we show the difference between a *projection* $f_h$ and an *interpolation*. In
+the interpolation, the function has the exact value at the nodes of the mesh,
+using a linear interpolation between the nodes. This is not the case for the
+projection. In fact, using a *discontinuous* Galerkin method, the basis
+functions are only defined on one cell each. Therefore, the projection is
+discontinuous at the cell boundaries.
+
+![Projection vs interpolation](https://sapphirepp.org/img/examples/visualization/visualization_projection_interpolation.png)
+
+Running @sapphire, we observed that at later time steps $t^n$, these
+discontinuities might be more pronounced in the numerical solution $f_h^n$, than
+those of the projection at the given time step $f_h(t^n)$. This becomes
+especially noticeable, if the analytic solution would be zero at some time,
+$f(t^n, x) = 0$. An example is the $f_{110}$ mode in the
+[convergence-study](#convergence-study) example.
+
+![Discontinuities](https://sapphirepp.org/img/examples/visualization/visualization_discontinuity_k1.gif)
+
+These jumps are a feature of the DG method and are not a sign of instability. In
+fact, error estimates for DG methods include estimated for the jump terms, see
+@cite Pietro_MathematicalAspectsDG. A typical example is the $L^2$ error
+estimate of a DG method is,
+
+$$
+  \|u^N - u_h^N\|_{L^2} + \left( \sum_m^{N-1} \delta t \sum_F \int_F \frac{1}{2}
+  |\beta \cdot n_F| [[u^m - u_h^m]]^2 \right)^{1/2}
+  \lesssim C (\Delta x)^a + D (\Delta t)^b \,.
+$$
+
+The second term on the left-hand side provides an estimate of the jumps at the
+cell boundaries, $[[u]] = \sum_j (u(x^+_{j+\frac{1}{2}}) -
+u(x^-_{j+\frac{1}{2}}))$. $a$, $b$, $C$, and $D$ are constants that bound the
+error. Concluding, we can see that the discontinuities are a feature of the DG
+method, that we can expect to be on the order of numerical errors.
 
 
-## Finite Elements {#fe-visualization}
+## Polynomial basis functions and deal.II output {#dealii-visualization}
 
-FE always does projections. Therefore, the FE presentation does not converge
-point wise, but only in the integral sense. This means that the FE solution can
-mismatch the analytical solution at every point, but still be an accurate
-presentation in the FE sense.
+In @sapphire, we use polynomial basis functions $\phi_i$ for the FE
+representation. More precisely, we Lagrange polynomials of degree $k$ on each
+cell. Representing these in a visualization programme, like ParaView and VisIt,
+turn out to be challenging. Most programmes expect a point wise representation
+of the solution, while the FE representation is given by the coefficients $f_i$.
+Hence, when saving the results @dealii "converts" it to point wise data, by
+giving the values on each node of the FE mesh. In the special case of first
+order polynomials $k=1$, this results in an exact representation of the
+numerical solution, as most visualisation programmes will linearly interpolate
+between the nodes. For higher order polynomials, @dealii provides the following
+workaround: it adds additional nodes to the mesh, representing the polynomials
+inside the cells. There are some important points to note:
 
-The FE representation has polynomials of degree $k$ on each cell. But most
-visualisation programme expect a point wise representation of the solutions.
-Hence, when saving the results we "convert" it to point wise data, by giving the
-values on each node of the FE mesh. If we have a polynomial of degree $k>1$ we
-add additional nodes to the mesh, representing the polynomials inside the cells.
-@note The nodes in the output mesh therefore do not correspond to the mesh used
-      in the simulation, if $k>1$.
-
-We use a DG method. This means that the solution is **discontinues** between
-the cells. Even the projection of a continuous function will be discontinues.
-Furthermore, each node is shared by multiple cells and therefore has multiple
-values.
-
-- `hdf5` format can only be used for `dim > 1`
-- `vtu` format allows representing higher order polynomials on a cell, if we
+- Each (cell-edge) node has multiple values, one for each cell it is part of.
+  (In 1D this corresponds to left- and right-sided values.)
+- For higher polynomial degree $k>1$, the nodes in the output mesh do not
+  correspond to the mesh used in the simulation, as @dealii introduces
+  additional cell-internal nodes.
+- The `hdf5` format can only be used for `dim > 1`
+- The `vtu` format allows representing higher order polynomials on a cell, if we
   activate the `write_higher_order_cells` flag. We are not using it so far!
+- If one wants "smoother" results, we recommend using higher order polynomials.
+  This is often more effective in reducing discontinuities than increasing the
+  mesh resolution. See for example the figure below.
+
+
+![Discontinuities for $k=2$](https://sapphirepp.org/img/examples/visualization/visualization_discontinuity_k2.png)
+
+
+This figure shows again the $f_{110}$ mode of the
+[convergence-study](#convergence-study) example, but with a higher polynomial
+degree of $k=2$. One can see that the discontinuities much less pronounced than
+in the $k=1$ case (figure in previous section).
 
 
 ## VFP modules specialities {#vfp-visualization}
+
+In the VFP module in @sapphire, we have to consider some additional points when
+visualizing and interpreting the results:
 
 - @sapphire uses an expansion into spherical harmonics. It output these
   expansion coefficients, $f_{lms}$ labelled `f_lms`. It does *not* the give the
   distribution function $f$.
 - @sapphire uses *mixed coordinates*. The corresponding laboratory frame
   momentum does depend on the position *and* direction of the particles (the
-  background velocity is a vector field $\mathbf{u}(\mathbf{x}$). Because we
+  background velocity is a vector field $\mathbf{u}(\mathbf{x})$). Because we
   expand the momentum dependence into spherical harmonics, there is no simple
   conversion between the absolute value of the momentum in laboratory frame and
   mixed coordinates. If you want to compare your result, always make sure that
@@ -51,19 +128,27 @@ values.
 
 ## ParaView {#paraview-visualization}
 
-- It uses the values given at the nodes and linearly interpolates between them
-  inside each cell.
+Here we want to give you some tips and tricks we learned when using
+[ParaView](https://www.paraview.org) to visualize the results of @sapphire:
+
+- ParaView uses the values given at the nodes and linearly interpolates between
+  them inside each cell.
 - ParaView has problems reading the mesh data (especially in the 1D case).
-  Therefore, one should *not* use the options `Sample At Cell Boundaries` or
-  `Sample At Segment Centers` when using the `PlotOverLine` feature. Instead,
-  one should use the option `Sample Uniformly`. It is recommended to choose a
-  `Resolution` equal to the number of cells in the mesh, to sample one point per
-  cell and get a smooth representation of the solution without jumps of the DG
-  method.
+  Therefore, when using the `PlotOverLine` feature one should *not* use the
+  `Sample At Cell Boundaries` or `Sample At Segment Centers` options. Instead,
+  one should use the option `Sample Uniformly`.
+- If you want to show "smooth" results without jumps introduced by the DG
+  method, one way is to show only the cell average. In the $k=1$ case this is
+  equal to the cell-midpoint value. Using `PlotOverLine:Sample Uniformly` this
+  can be accomplished by choosing a `Resolution` equal to the number of cells in
+  the mesh. For higher order polynomials $k>0$, there is no direct way to
+  visualize the cell average.  
+  @note Continuously connecting points other than the cell average can lead to
+    misleading representations.
 - When using the `PlotOverLine` feature in 2D or 3D, one should make sure to
-  *not* sample along a cell boundary. Otherwise, the solution will have 4/8 or
-  more values at a node (one from each neighbouring cell). ParaView is not able
-  to interpret this and will show a wrong representation of the solution. We
+  *not* sample along a cell boundary. Otherwise, the solution will have 4/8
+  values at a node (one from each neighbouring cell). ParaView is not able to
+  interpret this and will show a wrong representation of the solution. We
   recommend using a small offset from the cell boundary when using this feature.
   Combined with using the `Sample Uniformly` option, this will ensure the
   solution is only sampled inside a cell, where the solution is well-defined.
@@ -81,4 +166,4 @@ values.
 ---
 
 @author Florian Schulze (<florian.schulze@mpi-hd.mpg.de>)
-@date 2024-01-25
+@date 2024-03-08

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(parallel-shock)
 add_subdirectory(gyro-advection)
 add_subdirectory(scattering-only)
+add_subdirectory(convergence-study)

--- a/examples/convergence-study/CMakeLists.txt
+++ b/examples/convergence-study/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(convergence-study convergence-study.cpp ${VFP_SOURCES})
+deal_ii_setup_target(convergence-study)
+file(GLOB CONFIG_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(convergence-study PUBLIC ${CONFIG_HEADER_DIR})
+target_include_directories(convergence-study PUBLIC
+                           ${PROJECT_SOURCE_DIR}/include/sapphirepp/vfp)
+target_link_libraries(convergence-study UtilsLib)
+
+file(COPY parameter.prm DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/results"
+)

--- a/examples/convergence-study/config.h
+++ b/examples/convergence-study/config.h
@@ -1,0 +1,403 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the Sapphire++ authors
+//
+// This file is part of Sapphire++.
+//
+// Sapphire++ is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// Sapphire++ is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sapphire++. If not, see <https://www.gnu.org/licenses/>.
+//
+// -----------------------------------------------------------------------------
+
+/**
+ * @file examples/convergence-study/config.h
+ * @author Florian Schulze (florian.schulze@mpi-hd.mpg.de)
+ * @brief Implement physical setup for convergence-study example
+ */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/point.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <cmath>
+#include <vector>
+
+#include "pde-system.h"
+#include "sapphirepp-logstream.h"
+#include "vfp-flags.h"
+
+
+
+namespace sapphirepp
+{
+  class PhysicalParameters
+  {
+  public:
+    /** [Define runtime parameter] */
+    double B0_2pi;
+    double B0;
+    /** [Define runtime parameter] */
+    // Copy of VFP parameters for inital value function
+    double velocity;
+    double gamma;
+    double charge;
+    double mass;
+    double box_length;
+
+    PhysicalParameters() = default;
+
+
+
+    void
+    declare_parameters(dealii::ParameterHandler &prm)
+    {
+      dealii::LogStream::Prefix pre1("Startup", saplog);
+      dealii::LogStream::Prefix pre2("Physical parameters", saplog);
+      saplog << "Declaring parameters" << std::endl;
+      prm.enter_subsection("Physical parameters");
+
+      /** [Declare runtime parameter] */
+      prm.declare_entry("B0/2pi",
+                        "1.",
+                        dealii::Patterns::Double(),
+                        "Magnetic field strength");
+      /** [Declare runtime parameter] */
+
+      prm.leave_subsection();
+    }
+
+
+
+    void
+    parse_parameters(dealii::ParameterHandler &prm)
+    {
+      dealii::LogStream::Prefix pre1("Startup", saplog);
+      dealii::LogStream::Prefix pre2("PhysicalParameters", saplog);
+      saplog << "Parsing parameters" << std::endl;
+      prm.enter_subsection("Physical parameters");
+
+      /** [Parse runtime parameter]  */
+      B0_2pi = prm.get_double("B0/2pi");
+      B0     = B0_2pi * 2. * M_PI;
+      /** [Parse runtime parameter]  */
+
+      prm.leave_subsection();
+    }
+  };
+
+
+
+  namespace VFP
+  {
+    /** [Dimension] */
+    /** Specify reduced phase space dimension \f$ (\mathbf{x}, p) \f$ */
+    static constexpr unsigned int dimension = 1;
+    /** [Dimension] */
+
+
+
+    /** [VFP Flags] */
+    /** Specify which terms of the VFP equation should be active */
+    static constexpr VFPFlags vfp_flags = VFPFlags::spatial_advection |
+                                          VFPFlags::magnetic |
+                                          VFPFlags::time_independent_fields;
+    /** [VFP Flags] */
+
+
+
+    template <unsigned int dim>
+    class InitialValueFunction : public dealii::Function<dim>
+    {
+    public:
+      InitialValueFunction(const PhysicalParameters &physical_parameters,
+                           const unsigned int        exp_order)
+        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+        , prm{physical_parameters}
+        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+        , V{prm.velocity}
+        , L{prm.box_length}
+        , omega{prm.B0 * prm.charge / (prm.gamma * prm.mass)}
+      {}
+
+
+
+      void
+      vector_value(const dealii::Point<dim> &point,
+                   dealii::Vector<double>   &f) const override
+      {
+        AssertDimension(f.size(), this->n_components);
+        static_cast<void>(point); // suppress compiler warning
+
+        /** [Initial value] */
+        // 1D Fourier series analytic solution
+        f = 0;
+
+        const double t = this->get_time();
+        const double x = point[0];
+
+        for (unsigned int n = 1; n < 2; ++n)
+          {
+            const double A_n = 0.;
+            const double B_n = 1.;
+            const double k_n = n * 2. * M_PI / L;
+            const double c_n = V * k_n / std::sqrt(3.);
+
+            // f_000
+            f[0] += c_n / std::sqrt(omega * omega + c_n * c_n) *
+                    (std::cos(std::sqrt(omega * omega + c_n * c_n) * t) - 1. +
+                     (omega * omega + c_n * c_n) / (c_n * c_n)) *
+                    (A_n * std::cos(k_n * x) - B_n * std::sin(k_n * x));
+
+            // f_110
+            f[1] += omega / std::sqrt(omega * omega + c_n * c_n) *
+                    (1. - std::cos(std::sqrt(omega * omega + c_n * c_n) * t)) *
+                    (A_n * std::sin(k_n * x) + B_n * std::cos(k_n * x));
+
+            // f_100
+            f[2] += std::sin(std::sqrt(omega * omega + c_n * c_n) * t) *
+                    (A_n * std::sin(k_n * x) + B_n * std::cos(k_n * x));
+
+            // f_111
+            f[3] += 0.;
+          }
+        /** [Initial value] */
+      }
+
+
+
+    private:
+      const PhysicalParameters                       prm;
+      const std::vector<std::array<unsigned int, 3>> lms_indices;
+      const double                                   V;     /** Velocity */
+      const double                                   L;     /** Length */
+      const double                                   omega; /** Gyrofrequency */
+    };
+
+
+
+    template <unsigned int dim>
+    class ScatteringFrequency : public dealii::Function<dim>
+    {
+    public:
+      ScatteringFrequency(const PhysicalParameters &physical_parameters)
+        : dealii::Function<dim>(1)
+        , prm{physical_parameters}
+      {}
+
+
+
+      void
+      value_list(const std::vector<dealii::Point<dim>> &points,
+                 std::vector<double>                   &scattering_frequencies,
+                 const unsigned int component = 0) const override
+      {
+        AssertDimension(scattering_frequencies.size(), points.size());
+        static_cast<void>(component); // suppress compiler warning
+
+        for (unsigned int i = 0; i < points.size(); ++i)
+          {
+            /** [Scattering frequency] */
+            // No scattering frequency
+            scattering_frequencies[i] = 0;
+            /** [Scattering frequency] */
+          }
+      }
+
+
+
+    private:
+      const PhysicalParameters prm;
+    };
+
+
+
+    template <unsigned int dim>
+    class Source : public dealii::Function<dim>
+    {
+    public:
+      Source(const PhysicalParameters &physical_parameters,
+             unsigned int              exp_order)
+        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+        , prm{physical_parameters}
+        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+      {}
+
+
+
+      void
+      vector_value(const dealii::Point<dim> &point,
+                   dealii::Vector<double>   &source_values) const override
+      {
+        AssertDimension(source_values.size(), this->n_components);
+        static_cast<void>(point); // suppress compiler warning
+
+        for (unsigned int i = 0; i < source_values.size(); ++i)
+          {
+            /** [Source] */
+            // No Source
+            source_values[i] = 0.;
+            /** [Source] */
+          }
+      }
+
+
+
+    private:
+      const PhysicalParameters                       prm;
+      const std::vector<std::array<unsigned int, 3>> lms_indices;
+    };
+
+
+
+    template <unsigned int dim>
+    class MagneticField : public dealii::Function<dim>
+    {
+    public:
+      MagneticField(const PhysicalParameters &physical_parameters)
+        : dealii::Function<dim>(3)
+        , prm{physical_parameters}
+      {}
+
+
+
+      void
+      vector_value(const dealii::Point<dim> &point,
+                   dealii::Vector<double>   &magnetic_field) const override
+      {
+        AssertDimension(magnetic_field.size(), this->n_components);
+        static_cast<void>(point); // suppress compiler warning
+
+        /** [Magnetic field] */
+        magnetic_field[0] = 0.;     // B_x
+        magnetic_field[1] = 0.;     // B_y
+        magnetic_field[2] = prm.B0; // B_z
+        /** [Magnetic field] */
+      }
+
+
+
+    private:
+      const PhysicalParameters prm;
+    };
+
+
+
+    template <unsigned int dim>
+    class BackgroundVelocityField : public dealii::Function<dim>
+    {
+    public:
+      BackgroundVelocityField(const PhysicalParameters &physical_parameters)
+        : dealii::Function<dim>(3)
+        , prm{physical_parameters}
+      {}
+
+
+
+      void
+      vector_value(const dealii::Point<dim> &point,
+                   dealii::Vector<double>   &velocity) const override
+      {
+        AssertDimension(velocity.size(), this->n_components);
+        static_cast<void>(point); // suppress compiler warning
+
+        /** [Background velocity value] */
+        // zero velocity field
+        velocity[0] = 0.; // u_x
+        velocity[1] = 0.; // u_y
+        velocity[2] = 0.; // u_z
+        /** [Background velocity value] */
+      }
+
+
+
+      void
+      divergence_list(const std::vector<dealii::Point<dim>> &points,
+                      std::vector<double>                   &divergence)
+      {
+        AssertDimension(divergence.size(), points.size());
+        static_cast<void>(points); // suppress compiler warning
+
+        for (unsigned int i = 0; i < divergence.size(); ++i)
+          {
+            /** [Background velocity divergence] */
+            // div u
+            divergence[i] = 0.;
+            /** [Background velocity divergence] */
+          }
+      }
+
+
+
+      void
+      material_derivative_list(
+        const std::vector<dealii::Point<dim>> &points,
+        std::vector<dealii::Vector<double>>   &material_derivatives)
+      {
+        AssertDimension(material_derivatives.size(), points.size());
+        AssertDimension(material_derivatives[0].size(), this->n_components);
+
+        for (unsigned int i = 0; i < points.size(); ++i)
+          {
+            /** [Background velocity material derivative] */
+            // zero velocity field
+            material_derivatives[i][0] = 0.; // D/Dt u_x
+            material_derivatives[i][1] = 0.; // D/Dt u_y
+            material_derivatives[i][2] = 0.; // D/Dt u_z
+            /** [Background velocity material derivative] */
+          }
+      }
+
+
+
+      void
+      jacobian_list(
+        const std::vector<dealii::Point<dim>>            &points,
+        std::vector<std::vector<dealii::Vector<double>>> &jacobians) const
+      {
+        AssertDimension(jacobians.size(), points.size());
+        AssertDimension(jacobians[0].size(), this->n_components);
+        AssertDimension(jacobians[0][0].size(), this->n_components);
+
+        for (unsigned int i = 0; i < points.size(); ++i)
+          {
+            /** [Background velocity Jacobian] */
+            // zero velocity field
+            jacobians[i][0][0] = 0.; // \partial u_x / \partial x
+            jacobians[i][0][1] = 0.; // \partial u_x / \partial y
+            jacobians[i][0][2] = 0.; // \partial u_x / \partial z
+
+            jacobians[i][1][0] = 0.; // \partial u_y / \partial x
+            jacobians[i][1][1] = 0.; // \partial u_y / \partial y
+            jacobians[i][1][2] = 0.; // \partial u_y / \partial z
+
+            jacobians[i][2][0] = 0.; // \partial u_z / \partial x
+            jacobians[i][2][1] = 0.; // \partial u_z / \partial y
+            jacobians[i][2][2] = 0.; // \partial u_z / \partial z
+            /** [Background velocity Jacobian] */
+          }
+      }
+
+
+
+    private:
+      const PhysicalParameters prm;
+    };
+  } // namespace VFP
+} // namespace sapphirepp
+#endif

--- a/examples/convergence-study/convergence-study.cpp
+++ b/examples/convergence-study/convergence-study.cpp
@@ -1,0 +1,305 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the Sapphire++ authors
+//
+// This file is part of Sapphire++.
+//
+// Sapphire++ is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// Sapphire++ is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sapphire++. If not, see <https://www.gnu.org/licenses/>.
+//
+// -----------------------------------------------------------------------------
+
+/**
+ * @file examples/convergence-study/convergence-study.cpp
+ * @author Florian Schulze (florian.schulze@mpi-hd.mpg.de)
+ * @brief Implement main function for convergence-study example
+ */
+
+#include <deal.II/base/discrete_time.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/parameter_handler.h>
+
+#include <mpi.h>
+
+#include <fstream>
+#include <iostream>
+
+#include "config.h"
+#include "output-parameters.h"
+#include "sapphirepp-logstream.h"
+#include "vfp-parameters.h"
+#include "vfp-solver.h"
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      using namespace sapphirepp;
+      using namespace VFP;
+      dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc,
+                                                                  argv,
+                                                                  1);
+
+      saplog.init(3);
+
+      std::string parameter_filename = "parameter.prm";
+      if (argc > 1)
+        parameter_filename = argv[1];
+
+      dealii::ParameterHandler prm;
+      PhysicalParameters       physical_parameters;
+      Utils::OutputParameters  output_parameters;
+      VFPParameters<dimension> vfp_parameters;
+
+      physical_parameters.declare_parameters(prm);
+      output_parameters.declare_parameters(prm);
+      vfp_parameters.declare_parameters(prm);
+
+      prm.parse_input(parameter_filename);
+
+      physical_parameters.parse_parameters(prm);
+      output_parameters.parse_parameters(prm);
+      vfp_parameters.parse_parameters(prm);
+
+      AssertThrow(vfp_parameters.expansion_order == 1,
+                  dealii::ExcMessage("Expansion order be one."));
+
+      // Copy vfp_parameters to physical parameters for inital function
+      physical_parameters.velocity = vfp_parameters.velocity;
+      physical_parameters.gamma    = vfp_parameters.gamma;
+      physical_parameters.charge   = vfp_parameters.charge;
+      physical_parameters.mass     = vfp_parameters.mass;
+      physical_parameters.box_length =
+        std::abs(vfp_parameters.p1[0] - vfp_parameters.p2[0]);
+
+      const double gyroperiod =
+        vfp_parameters.gamma * vfp_parameters.mass /
+        (physical_parameters.B0_2pi * vfp_parameters.charge);
+      const double gyroradius =
+        vfp_parameters.gamma * vfp_parameters.mass * vfp_parameters.velocity /
+        (vfp_parameters.charge * physical_parameters.B0);
+      const double box_length =
+        std::abs(vfp_parameters.p1[0] - vfp_parameters.p2[0]);
+      saplog << "particle_velocity = " << vfp_parameters.velocity
+             << ", gyroperiod = " << gyroperiod
+             << ", gyroradius = " << gyroradius
+             << ", box_length = " << box_length
+             << ", final_time = " << vfp_parameters.final_time << std::endl;
+
+      if (std::fmod(vfp_parameters.final_time, gyroperiod) != 0.)
+        saplog << "Warning: Final time is not a multiple of the gyroperiod."
+               << std::endl;
+
+      std::ofstream error_file(output_parameters.output_path / "error.csv");
+      AssertThrow(!error_file.fail(),
+                  dealii::ExcFileNotOpen(output_parameters.output_path /
+                                         "error.csv"));
+      error_file << "timestep"
+                 << "; "
+                 << "time"
+                 << "; "
+                 << "L2_norm"
+                 << "; "
+                 << "L2_error"
+                 << "; "
+                 << "relative_error" << std::endl;
+
+      VFPSolver<dimension> vfp_solver(vfp_parameters,
+                                      physical_parameters,
+                                      output_parameters);
+      vfp_solver.setup();
+
+      const unsigned int num_exp_coefficients =
+        (vfp_parameters.expansion_order + 1) *
+        (vfp_parameters.expansion_order + 1);
+
+      InitialValueFunction<dimension> analytic_solution(
+        physical_parameters, vfp_parameters.expansion_order);
+      const dealii::ComponentSelectFunction<dimension> weight(
+        0, num_exp_coefficients);
+
+      PETScWrappers::MPI::Vector analytic_solution_vector;
+      analytic_solution_vector.reinit(
+        vfp_solver.get_dof_handler().locally_owned_dofs(), MPI_COMM_WORLD);
+
+      std::vector<std::string> component_names(num_exp_coefficients);
+      std::vector<std::string> component_names_interpol(num_exp_coefficients);
+      const std::vector<std::array<unsigned int, 3>> lms_indices =
+        PDESystem::create_lms_indices(num_exp_coefficients);
+      for (unsigned int i = 0; i < num_exp_coefficients; ++i)
+        {
+          const std::array<unsigned int, 3> &lms = lms_indices[i];
+          component_names[i] = "analytic_f_" + std::to_string(lms[0]) +
+                               std::to_string(lms[1]) + std::to_string(lms[2]);
+          component_names_interpol[i] =
+            "analytic_interpol_f_" + std::to_string(lms[0]) +
+            std::to_string(lms[1]) + std::to_string(lms[2]);
+        }
+
+      saplog << "Calculate analytic solution" << std::endl;
+
+      dealii::DataOut<dimension> data_out;
+      data_out.attach_dof_handler(vfp_solver.get_dof_handler());
+      analytic_solution.set_time(0.);
+
+
+      vfp_solver.project(analytic_solution, analytic_solution_vector);
+      data_out.add_data_vector(analytic_solution_vector, component_names);
+
+      dealii::VectorTools::interpolate(vfp_solver.get_dof_handler(),
+                                       analytic_solution,
+                                       analytic_solution_vector);
+      data_out.add_data_vector(analytic_solution_vector,
+                               component_names_interpol);
+
+      data_out.build_patches(vfp_parameters.polynomial_degree);
+      output_parameters.write_results<dimension>(data_out,
+                                                 0,
+                                                 0.,
+                                                 "analytic_solution");
+
+      saplog << "Compute error" << std::endl;
+      const double L2_error =
+        vfp_solver.compute_global_error(analytic_solution,
+                                        dealii::VectorTools::L2_norm,
+                                        dealii::VectorTools::L2_norm,
+                                        &weight);
+      const double L2_norm =
+        vfp_solver.compute_weighted_norm(dealii::VectorTools::L2_norm,
+                                         dealii::VectorTools::L2_norm,
+                                         &weight);
+
+      saplog << "L2_error = " << L2_error << ", L2_norm = " << L2_norm
+             << ", rel error = " << L2_error / L2_norm << std::endl;
+
+      error_file << 0 << "; " << 0.0 << "; " << L2_norm << "; " << L2_error
+                 << "; " << L2_error / L2_norm << std::endl;
+
+      DiscreteTime discrete_time(0,
+                                 vfp_parameters.final_time,
+                                 vfp_parameters.time_step);
+      for (; discrete_time.is_at_end() == false; discrete_time.advance_time())
+        {
+          {
+            LogStream::Prefix prefix("VFP", saplog);
+            saplog << "Time step " << std::setw(6) << std::right
+                   << discrete_time.get_step_number()
+                   << " at t = " << discrete_time.get_current_time() << " \t["
+                   << Utilities::System::get_time() << "]" << std::endl;
+
+            switch (vfp_parameters.time_stepping_method)
+              {
+                case TimeSteppingMethod::forward_euler:
+                case TimeSteppingMethod::backward_euler:
+                case TimeSteppingMethod::crank_nicolson:
+                  vfp_solver.theta_method(discrete_time.get_current_time(),
+                                          discrete_time.get_next_step_size());
+                  break;
+                case TimeSteppingMethod::erk4:
+                  vfp_solver.explicit_runge_kutta(
+                    discrete_time.get_current_time(),
+                    discrete_time.get_next_step_size());
+                  break;
+                case TimeSteppingMethod::lserk:
+                  vfp_solver.low_storage_explicit_runge_kutta(
+                    discrete_time.get_current_time(),
+                    discrete_time.get_next_step_size());
+                  break;
+                default:
+                  AssertThrow(false, ExcNotImplemented());
+              }
+
+            vfp_solver.output_results(discrete_time.get_step_number() + 1,
+                                      discrete_time.get_next_time());
+          }
+
+          LogStream::Prefix prefix2("analytic", saplog);
+          saplog << "Calculate analytic solution" << std::endl;
+          analytic_solution.set_time(discrete_time.get_next_time());
+
+          if ((discrete_time.get_step_number() + 1) %
+                output_parameters.output_frequency ==
+              0)
+            {
+              dealii::DataOut<dimension> data_out;
+              data_out.attach_dof_handler(vfp_solver.get_dof_handler());
+              vfp_solver.project(analytic_solution, analytic_solution_vector);
+              data_out.add_data_vector(analytic_solution_vector,
+                                       component_names);
+
+              dealii::VectorTools::interpolate(vfp_solver.get_dof_handler(),
+                                               analytic_solution,
+                                               analytic_solution_vector);
+              data_out.add_data_vector(analytic_solution_vector,
+                                       component_names_interpol);
+
+              data_out.build_patches(vfp_parameters.polynomial_degree);
+              output_parameters.write_results<dimension>(
+                data_out,
+                discrete_time.get_step_number() + 1,
+                discrete_time.get_next_time(),
+                "analytic_solution");
+            }
+
+          saplog << "Compute error" << std::endl;
+          const double L2_error =
+            vfp_solver.compute_global_error(analytic_solution,
+                                            dealii::VectorTools::L2_norm,
+                                            dealii::VectorTools::L2_norm,
+                                            &weight);
+          const double L2_norm =
+            vfp_solver.compute_weighted_norm(dealii::VectorTools::L2_norm,
+                                             dealii::VectorTools::L2_norm,
+                                             &weight);
+
+          saplog << "L2_error = " << L2_error << ", L2_norm = " << L2_norm
+                 << ", rel error = " << L2_error / L2_norm << std::endl;
+
+          error_file << discrete_time.get_step_number() + 1 << "; "
+                     << discrete_time.get_next_time() << "; " << L2_norm << "; "
+                     << L2_error << "; " << L2_error / L2_norm << std::endl;
+        }
+      saplog << "Simulation ended at t = " << discrete_time.get_current_time()
+             << " \t[" << Utilities::System::get_time() << "]" << std::endl;
+
+      error_file.close();
+      vfp_solver.get_timer().print_wall_time_statistics(MPI_COMM_WORLD);
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  return 0;
+}

--- a/examples/convergence-study/parameter.prm
+++ b/examples/convergence-study/parameter.prm
@@ -1,0 +1,41 @@
+subsection Output
+  set Base file name               = solution
+  set Format                       = vtu
+  set Number of digits for counter = 5
+  set Output frequency             = 20
+end
+subsection Physical parameters
+  set B0/2pi = 1.
+end
+subsection VFP
+  subsection Expansion
+    set Expansion order = 1
+  end
+  subsection Finite element
+    set Polynomial degree = 3
+  end
+  subsection Mesh
+    set Grid type             = Hypercube
+    set Number of cells       = 8
+    set Point 1               = -10.
+    set Point 2               = 10.
+    subsection Boundary conditions
+      set lower x = periodic
+      set lower y = periodic
+      set upper x = periodic
+      set upper y = periodic
+    end
+  end
+  subsection Particle properties
+    set Charge = 1.
+    set Mass   = 1.
+  end
+  subsection Time stepping
+    set Final time     = 20.
+    set Method         = FE
+    set Time step size = 0.02
+  end
+  subsection TransportOnly
+    set Gamma = 2.
+  end
+end

--- a/examples/gyro-advection/config.h
+++ b/examples/gyro-advection/config.h
@@ -130,10 +130,10 @@ namespace sapphirepp
     {
     public:
       InitialValueFunction(const PhysicalParameters &physical_parameters,
-                           const unsigned int        exp_order)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+                           const unsigned int        system_size)
+        : dealii::Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{PDESystem::create_lms_indices(system_size)}
       {}
 
 
@@ -207,10 +207,10 @@ namespace sapphirepp
     {
     public:
       Source(const PhysicalParameters &physical_parameters,
-             unsigned int              exp_order)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+             unsigned int              system_size)
+        : dealii::Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{PDESystem::create_lms_indices(system_size)}
       {}
 
 

--- a/examples/parallel-shock/config.h
+++ b/examples/parallel-shock/config.h
@@ -183,10 +183,10 @@ namespace sapphirepp
     {
     public:
       InitialValueFunction(const PhysicalParameters &physical_parameters,
-                           const unsigned int        exp_order)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+                           const unsigned int        system_size)
+        : dealii::Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{PDESystem::create_lms_indices(system_size)}
       {}
 
 
@@ -258,10 +258,10 @@ namespace sapphirepp
     {
     public:
       Source(const PhysicalParameters &physical_parameters,
-             unsigned int              exp_order)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+             unsigned int              system_size)
+        : dealii::Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{PDESystem::create_lms_indices(system_size)}
       {}
 
 

--- a/examples/scattering-only/config.h
+++ b/examples/scattering-only/config.h
@@ -130,10 +130,10 @@ namespace sapphirepp
     {
     public:
       InitialValueFunction(const PhysicalParameters &physical_parameters,
-                           const unsigned int        exp_order)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+                           const unsigned int        system_size)
+        : dealii::Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{PDESystem::create_lms_indices(system_size)}
       {}
       /** [InitialValueFunction constructor] */
 
@@ -208,10 +208,10 @@ namespace sapphirepp
     {
     public:
       Source(const PhysicalParameters &physical_parameters,
-             unsigned int              exp_order)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+             unsigned int              system_size)
+        : dealii::Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{PDESystem::create_lms_indices(system_size)}
       {}
 
 

--- a/examples/scattering-only/scattering-only.cpp
+++ b/examples/scattering-only/scattering-only.cpp
@@ -53,11 +53,11 @@ namespace sapinternal
     {
     public:
       AnalyticSolution(const PhysicalParameters &physical_parameters,
-                       const unsigned int        exp_order,
+                       const unsigned int        system_size,
                        const double              time)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1), time)
+        : dealii::Function<dim>(system_size, time)
         , prm{physical_parameters}
-        , lms_indices{VFP::PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{VFP::PDESystem::create_lms_indices(system_size)}
       {}
       /** [AnalyticSolution constructor] */
 
@@ -152,7 +152,7 @@ main(int argc, char *argv[])
 
       AnalyticSolution<dimension> analytic_solution(
         physical_parameters,
-        vfp_parameters.expansion_order,
+        vfp_solver.get_pde_system().system_size,
         vfp_parameters.final_time);
       /** [Create AnalyticSolution] */
 

--- a/examples/scattering-only/scattering-only.cpp
+++ b/examples/scattering-only/scattering-only.cpp
@@ -178,28 +178,18 @@ main(int argc, char *argv[])
                                        analytic_solution_vector);
       /** [Calculate analytic solution] */
 
-      /** [Component names] */
-      const unsigned int num_exp_coefficients =
-        (vfp_parameters.expansion_order + 1) *
-        (vfp_parameters.expansion_order + 1);
-      std::vector<std::string> component_names(num_exp_coefficients);
-      const std::vector<std::array<unsigned int, 3>> lms_indices =
-        PDESystem::create_lms_indices(num_exp_coefficients);
-      for (unsigned int i = 0; i < num_exp_coefficients; ++i)
-        {
-          const std::array<unsigned int, 3> &lms = lms_indices[i];
-          component_names[i] = "analytic_f_" + std::to_string(lms[0]) +
-                               std::to_string(lms[1]) + std::to_string(lms[2]);
-        }
-      /** [Component names] */
-
       /** [Output analytic solution] */
       dealii::DataOut<dimension> data_out;
       data_out.attach_dof_handler(vfp_solver.get_dof_handler());
-      data_out.add_data_vector(analytic_solution_vector, component_names);
+      data_out.add_data_vector(analytic_solution_vector,
+                               PDESystem::create_component_name_list(
+                                 vfp_solver.get_pde_system().system_size,
+                                 "analytic_f_"));
       data_out.build_patches(vfp_parameters.polynomial_degree);
-      output_parameters.base_file_name = "analytic_solution";
-      output_parameters.write_results<dimension>(data_out, 0);
+      output_parameters.write_results<dimension>(data_out,
+                                                 0,
+                                                 vfp_parameters.final_time,
+                                                 "analytic_solution");
       /** [Output analytic solution] */
       /** [Try-Catch end] */
     }

--- a/include/config.h
+++ b/include/config.h
@@ -143,13 +143,14 @@ namespace sapphirepp
        * @brief Constructor
        *
        * @param physical_parameters User defined runtime parameters
-       * @param exp_order Maximum expansion order \f$ l_{\rm max} \f$
+       * @param system_size Number of expansion coefficients, normally
+       *        \f$ (l_{\rm max} + 1)^2 \f$
        */
       InitialValueFunction(const PhysicalParameters &physical_parameters,
-                           const unsigned int        exp_order)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+                           const unsigned int        system_size)
+        : dealii::Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{PDESystem::create_lms_indices(system_size)}
       {}
 
 
@@ -300,13 +301,14 @@ namespace sapphirepp
        * @brief Constructor
        *
        * @param physical_parameters User defined runtime parameters
-       * @param exp_order Maximum expansion order \f$ l_{\rm max} \f$
+       * @param system_size Number of expansion coefficients, normally
+       *        \f$ (l_{\rm max} + 1)^2 \f$
        */
       Source(const PhysicalParameters &physical_parameters,
-             unsigned int              exp_order)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1))
+             unsigned int              system_size)
+        : dealii::Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{PDESystem::create_lms_indices(system_size)}
       {}
 
 

--- a/include/sapphirepp/vfp/pde-system.h
+++ b/include/sapphirepp/vfp/pde-system.h
@@ -34,6 +34,7 @@
 
 #include <array>
 #include <ostream>
+#include <string>
 #include <vector>
 
 namespace sapphirepp
@@ -77,6 +78,7 @@ namespace sapphirepp
       PDESystem(const unsigned int expansion_order);
 
 
+      /** @{ */
       /**
        * @brief Create a mapping between the system index \f$ i \f$ and the
        *        spherical harmonic indices \f$ (l,m,s) \f$
@@ -88,6 +90,20 @@ namespace sapphirepp
        */
       static std::vector<std::array<unsigned int, 3>>
       create_lms_indices(const unsigned int system_size);
+
+      /**
+       * @brief Create a list of component names, `f_lms`
+       *
+       * @param system_size Number of expansion coefficients, normally
+       *        \f$ (l_{\rm max} + 1)^2 \f$.
+       * @param prefix Prefix for the component names.
+       * @return std::vector<std::string> component_names.
+       *         List `component_names[i] = "f_lms"`.
+       */
+      static std::vector<std::string>
+      create_component_name_list(const unsigned int system_size,
+                                 const std::string &prefix = "f_");
+      /** @} */
 
 
 

--- a/include/sapphirepp/vfp/pde-system.h
+++ b/include/sapphirepp/vfp/pde-system.h
@@ -81,13 +81,13 @@ namespace sapphirepp
        * @brief Create a mapping between the system index \f$ i \f$ and the
        *        spherical harmonic indices \f$ (l,m,s) \f$
        *
-       * @param expansion_order Maximum order of the spherical harmonic
-       *        expansion \f$ l_{\rm max} \f$
+       * @param system_size Number of expansion coefficients, normally
+       *        \f$ (l_{\rm max} + 1)^2 \f$.
        * @return std::vector<std::array<unsigned int, 3>> lms_indices.
        *         Mapping `lms_indices[i] = {l,m,s}`.
        */
       static std::vector<std::array<unsigned int, 3>>
-      create_lms_indices(const unsigned int expansion_order);
+      create_lms_indices(const unsigned int system_size);
 
 
 

--- a/include/sapphirepp/vfp/vfp-solver.h
+++ b/include/sapphirepp/vfp/vfp-solver.h
@@ -375,10 +375,6 @@ namespace sapphirepp
       /** @{ */
       /** @ref PDESystem */
       PDESystem pde_system;
-      /** Maximum expansion order \f$ l_{\rm max} \f$ */
-      const unsigned int expansion_order;
-      /** Number of expansion coefficients, same as `pde_system.size`*/
-      const unsigned int num_exp_coefficients;
       /** @} */
 
       /** @ref UpwindFlux */

--- a/include/sapphirepp/vfp/vfp-solver.h
+++ b/include/sapphirepp/vfp/vfp-solver.h
@@ -316,6 +316,14 @@ namespace sapphirepp
        * @{
        */
       /**
+       * @brief Get the PDE system object
+       *
+       * @return const PDESystem&
+       */
+      const PDESystem &
+      get_pde_system() const;
+
+      /**
        * @brief Get the triangulation object
        *
        * @return const Triangulation&

--- a/src/vfp/pde-system.cpp
+++ b/src/vfp/pde-system.cpp
@@ -605,21 +605,18 @@ void
 sapphirepp::VFP::PDESystem::shrink_matrices()
 {
   // Shrink the matrices such that they agree with order of the expansion
-  unsigned int num_exp_coefficients =
-    (expansion_order + 1) * (expansion_order + 1);
-
   for (auto &advection_matrix : advection_matrices)
-    advection_matrix.grow_or_shrink(num_exp_coefficients);
+    advection_matrix.grow_or_shrink(system_size);
 
   for (auto &generator_matrix : generator_rotation_matrices)
-    generator_matrix.grow_or_shrink(num_exp_coefficients);
+    generator_matrix.grow_or_shrink(system_size);
 
   for (auto &adv_mat_product : adv_mat_products)
-    adv_mat_product.grow_or_shrink(num_exp_coefficients);
+    adv_mat_product.grow_or_shrink(system_size);
 
   for (auto &adv_x_gen_mat : adv_x_gen_matrices)
-    adv_x_gen_mat.grow_or_shrink(num_exp_coefficients);
+    adv_x_gen_mat.grow_or_shrink(system_size);
 
   for (auto &t_mat : t_matrices)
-    t_mat.grow_or_shrink(num_exp_coefficients);
+    t_mat.grow_or_shrink(system_size);
 }

--- a/src/vfp/pde-system.cpp
+++ b/src/vfp/pde-system.cpp
@@ -76,6 +76,26 @@ sapphirepp::VFP::PDESystem::create_lms_indices(const unsigned int system_size)
 
 
 
+std::vector<std::string>
+sapphirepp::VFP::PDESystem::create_component_name_list(
+  const unsigned int system_size,
+  const std::string &prefix)
+{
+  const std::vector<std::array<unsigned int, 3>> lms_indices =
+    PDESystem::create_lms_indices(system_size);
+  std::vector<std::string> component_names(system_size);
+
+  for (unsigned int i = 0; i < system_size; ++i)
+    {
+      component_names[i] = prefix + std::to_string(lms_indices[i][0]) +
+                           std::to_string(lms_indices[i][1]) +
+                           std::to_string(lms_indices[i][2]);
+    }
+  return component_names;
+}
+
+
+
 const std::vector<dealii::LAPACKFullMatrix<double>> &
 sapphirepp::VFP::PDESystem::get_advection_matrices() const
 {

--- a/src/vfp/pde-system.cpp
+++ b/src/vfp/pde-system.cpp
@@ -33,7 +33,7 @@
 sapphirepp::VFP::PDESystem::PDESystem(unsigned int expansion_order)
   : expansion_order{expansion_order}
   , system_size{(expansion_order + 1) * (expansion_order + 1)}
-  , lms_indices{create_lms_indices(expansion_order)}
+  , lms_indices{create_lms_indices(system_size)}
   , advection_matrices(3)
   , generator_rotation_matrices(3)
   , adv_mat_products(6)
@@ -52,27 +52,23 @@ sapphirepp::VFP::PDESystem::PDESystem(unsigned int expansion_order)
 
 
 std::vector<std::array<unsigned int, 3>>
-sapphirepp::VFP::PDESystem::create_lms_indices(
-  const unsigned int expansion_order)
+sapphirepp::VFP::PDESystem::create_lms_indices(const unsigned int system_size)
 {
-  const unsigned int system_size =
-    (expansion_order + 1) * (expansion_order + 1);
   std::vector<std::array<unsigned int, 3>> lms_indices(system_size);
-  for (long s = 0; s <= 1; ++s)
+
+  unsigned int l = 0;
+  long         m = 0;
+  for (unsigned int i = 0; i < system_size; ++i)
     {
-      for (long l = 0; l <= static_cast<long>(expansion_order); ++l)
+      lms_indices[i][0] = l;
+      lms_indices[i][1] = static_cast<unsigned int>(std::abs(m));
+      lms_indices[i][2] = m <= 0 ? 0 : 1;
+
+      m++;
+      if (m > static_cast<long>(l))
         {
-          for (long m = s; m <= l; ++m)
-            {
-              const long index = l * (l + 1) - (s ? -1 : 1) * m;
-              AssertIndexRange(index, system_size);
-              lms_indices[static_cast<unsigned int>(index)][0] =
-                static_cast<unsigned int>(l);
-              lms_indices[static_cast<unsigned int>(index)][1] =
-                static_cast<unsigned int>(m);
-              lms_indices[static_cast<unsigned int>(index)][2] =
-                static_cast<unsigned int>(s);
-            }
+          l++;
+          m = -static_cast<long>(l);
         }
     }
   return lms_indices;

--- a/src/vfp/vfp-solver.cpp
+++ b/src/vfp/vfp-solver.cpp
@@ -278,7 +278,7 @@ sapphirepp::VFP::VFPSolver<dim>::setup()
   {
     TimerOutput::Scope timer_section(timer, "Project initial condition");
     InitialValueFunction<dim_ps> initial_value_function(physical_parameters,
-                                                        expansion_order);
+                                                        pde_system.system_size);
     PETScWrappers::MPI::Vector   initial_condition(locally_owned_dofs,
                                                  mpi_communicator);
     project(initial_value_function, initial_condition);
@@ -295,7 +295,8 @@ sapphirepp::VFP::VFPSolver<dim>::setup()
   // Source term at t = 0;
   if constexpr ((vfp_flags & VFPFlags::source) != VFPFlags::none)
     {
-      Source<dim_ps> source_function(physical_parameters, expansion_order);
+      Source<dim_ps> source_function(physical_parameters,
+                                     pde_system.system_size);
       source_function.set_time(0);
       compute_source_term(source_function);
     }
@@ -1549,7 +1550,8 @@ sapphirepp::VFP::VFPSolver<dim>::theta_method(const double time,
         {
           system_rhs.add((1 - theta) * time_step, locally_owned_current_source);
           // Update the source term
-          Source<dim_ps> source_function(physical_parameters, expansion_order);
+          Source<dim_ps> source_function(physical_parameters,
+                                         pde_system.system_size);
           source_function.set_time(time + time_step);
           compute_source_term(source_function);
           system_rhs.add(theta * time_step, locally_owned_current_source);
@@ -1666,7 +1668,8 @@ sapphirepp::VFP::VFPSolver<dim>::explicit_runge_kutta(const double time,
       if constexpr ((vfp_flags & VFPFlags::time_independent_source) ==
                     VFPFlags::none) // time dependent source
         {
-          Source<dim_ps> source_function(physical_parameters, expansion_order);
+          Source<dim_ps> source_function(physical_parameters,
+                                         pde_system.system_size);
           source_function.set_time(time + c[1] * time_step);
           compute_source_term(source_function);
           system_rhs.add(-1., locally_owned_current_source);
@@ -1695,7 +1698,8 @@ sapphirepp::VFP::VFPSolver<dim>::explicit_runge_kutta(const double time,
       if constexpr ((vfp_flags & VFPFlags::time_independent_source) ==
                     VFPFlags::none) // time dependent source
         {
-          Source<dim_ps> source_function(physical_parameters, expansion_order);
+          Source<dim_ps> source_function(physical_parameters,
+                                         pde_system.system_size);
           source_function.set_time(time + c[2] * time_step);
           compute_source_term(source_function);
           system_rhs.add(-1., locally_owned_current_source);
@@ -1730,7 +1734,8 @@ sapphirepp::VFP::VFPSolver<dim>::explicit_runge_kutta(const double time,
       if constexpr ((vfp_flags & VFPFlags::time_independent_source) ==
                     VFPFlags::none) // time dependent source
         {
-          Source<dim_ps> source_function(physical_parameters, expansion_order);
+          Source<dim_ps> source_function(physical_parameters,
+                                         pde_system.system_size);
           source_function.set_time(time + c[3] * time_step);
           compute_source_term(source_function);
           system_rhs.add(-1., locally_owned_current_source);
@@ -1818,7 +1823,7 @@ sapphirepp::VFP::VFPSolver<dim>::low_storage_explicit_runge_kutta(
                         VFPFlags::none) // time dependent source
             {
               Source<dim_ps> source_function(physical_parameters,
-                                             expansion_order);
+                                             pde_system.system_size);
               source_function.set_time(time + c[s] * time_step);
               compute_source_term(source_function);
               system_rhs.add(-1., locally_owned_current_source);

--- a/src/vfp/vfp-solver.cpp
+++ b/src/vfp/vfp-solver.cpp
@@ -1860,18 +1860,9 @@ sapphirepp::VFP::VFPSolver<dim>::output_results(
   TimerOutput::Scope timer_section(timer, "Output");
   DataOut<dim_ps>    data_out;
   data_out.attach_dof_handler(dof_handler);
-  // Create a vector of strings with names for the components of the
-  // solution
-  std::vector<std::string> component_names(pde_system.system_size);
-
-  for (unsigned int i = 0; i < pde_system.system_size; ++i)
-    {
-      const std::array<unsigned int, 3> &lms = pde_system.lms_indices[i];
-      component_names[i]                     = "f_" + std::to_string(lms[0]) +
-                           std::to_string(lms[1]) + std::to_string(lms[2]);
-    }
-
-  data_out.add_data_vector(locally_relevant_current_solution, component_names);
+  data_out.add_data_vector(locally_relevant_current_solution,
+                           PDESystem::create_component_name_list(
+                             pde_system.system_size));
 
   // Output the partition of the mesh
   Vector<float> subdomain(triangulation.n_active_cells());

--- a/src/vfp/vfp-solver.cpp
+++ b/src/vfp/vfp-solver.cpp
@@ -1959,6 +1959,15 @@ sapphirepp::VFP::VFPSolver<dim>::compute_weighted_norm(
 
 
 template <unsigned int dim>
+const sapphirepp::VFP::PDESystem &
+sapphirepp::VFP::VFPSolver<dim>::get_pde_system() const
+{
+  return pde_system;
+}
+
+
+
+template <unsigned int dim>
 const typename sapphirepp::VFP::VFPSolver<dim>::Triangulation &
 sapphirepp::VFP::VFPSolver<dim>::get_triangulation() const
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,3 +20,4 @@ set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES
 add_subdirectory(parallel-shock)
 add_subdirectory(gyro-advection)
 add_subdirectory(scattering-only)
+add_subdirectory(convergence-study)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ add_test(NAME quick-start
 set_property(TEST quick-start PROPERTY
              LABELS "quick-start"
                     "2d" "momentum" "spatial_advection" "source" "scattering"
-                    "shock" "Crank-Nicholson"
+                    "shock" "CN"
                     "commit-Release" "commit-Debug"
                     "full-suite-Release" "full-suite-Debug")
 

--- a/tests/convergence-study/CMakeLists.txt
+++ b/tests/convergence-study/CMakeLists.txt
@@ -15,7 +15,7 @@ add_test(NAME convergence-study-CN
 set_property(TEST convergence-study-CN PROPERTY
              LABELS "convergence-study"
                     "1d" "spatial_advection" "magnetic"
-                    "Crank-Nicholson" "periodic BC"
+                    "CN" "periodic BC"
                     "fast" "commit-Debug" "commit-Release"
                     "full-suite-Release" "full-suite-Debug")
 

--- a/tests/convergence-study/CMakeLists.txt
+++ b/tests/convergence-study/CMakeLists.txt
@@ -1,0 +1,58 @@
+file(COPY parameter-CN.prm parameter-ERK4.prm parameter-LSERK.prm
+          parameter-FE.prm parameter-BE.prm
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+
+add_executable(test-convergence-study test-convergence-study.cpp ${VFP_SOURCES})
+deal_ii_setup_target(test-convergence-study)
+file(GLOB CONFIG_HEADER_DIR ${PROJECT_SOURCE_DIR}/examples/convergence-study)
+target_include_directories(test-convergence-study PUBLIC ${PROJECT_SOURCE_DIR}/include/sapphirepp/vfp)
+target_include_directories(test-convergence-study PUBLIC ${CONFIG_HEADER_DIR})
+target_link_libraries(test-convergence-study UtilsLib)
+
+add_test(NAME convergence-study-CN
+         COMMAND ./test-convergence-study parameter-CN.prm 5e-6)
+set_property(TEST convergence-study-CN PROPERTY
+             LABELS "convergence-study"
+                    "1d" "spatial_advection" "magnetic"
+                    "Crank-Nicholson" "periodic BC"
+                    "fast" "commit-Debug" "commit-Release"
+                    "full-suite-Release" "full-suite-Debug")
+
+add_test(NAME convergence-study-ERK4
+         COMMAND ./test-convergence-study parameter-ERK4.prm 1e-8)
+set_property(TEST convergence-study-ERK4 PROPERTY
+             LABELS "convergence-study"
+                    "1d" "scattering"
+                    "ERK4" "periodic BC"
+                    "fast" "commit-Debug" "commit-Release"
+                    "full-suite-Release" "full-suite-Debug")
+
+# add_test(NAME convergence-study-LSERK
+#          COMMAND ./test-convergence-study parameter-LSERK.prm 1e-8)
+# set_property(TEST convergence-study-LSERK PROPERTY
+#              LABELS "convergence-study"
+#                     "1d" "scattering"
+#                     "LSERK" "periodic BC"
+#                     "full-suite-Debug" "full-suite-Release")
+
+add_test(NAME convergence-study-FE
+         COMMAND ./test-convergence-study parameter-FE.prm 2e-3)
+set_property(TEST convergence-study-FE PROPERTY
+             LABELS "convergence-study"
+                    "1d" "scattering"
+                    "FE" "periodic BC"
+                    "full-suite-Debug" "full-suite-Release")
+
+add_test(NAME convergence-study-BE
+         COMMAND ./test-convergence-study parameter-BE.prm 6e-4)
+set_property(TEST convergence-study-BE PROPERTY
+             LABELS "convergence-study"
+                    "1d" "scattering"
+                    "BE" "periodic BC"
+                    "full-suite-Debug" "full-suite-Release")
+
+
+set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/results"
+)

--- a/tests/convergence-study/parameter-BE.prm
+++ b/tests/convergence-study/parameter-BE.prm
@@ -4,7 +4,7 @@ subsection Output
   set Number of digits for counter = 5
   set Output frequency             = 20
   set Results folder               = ./results
-  set Simulation identifier        = convergence-study
+  set Simulation identifier        = convergence-study-BE
 end
 subsection Physical parameters
   set B0/2pi = 1.
@@ -18,7 +18,7 @@ subsection VFP
   end
   subsection Mesh
     set Grid type             = Hypercube
-    set Number of cells       = 8
+    set Number of cells       = 64
     set Point 1               = -10.
     set Point 2               = 10.
     subsection Boundary conditions
@@ -32,7 +32,7 @@ subsection VFP
   end
   subsection Time stepping
     set Final time     = 20.
-    set Method         = FE
+    set Method         = BE
     set Time step size = 0.01
   end
   subsection TransportOnly

--- a/tests/convergence-study/parameter-CN.prm
+++ b/tests/convergence-study/parameter-CN.prm
@@ -4,7 +4,7 @@ subsection Output
   set Number of digits for counter = 5
   set Output frequency             = 20
   set Results folder               = ./results
-  set Simulation identifier        = convergence-study
+  set Simulation identifier        = convergence-study-CN
 end
 subsection Physical parameters
   set B0/2pi = 1.
@@ -18,7 +18,7 @@ subsection VFP
   end
   subsection Mesh
     set Grid type             = Hypercube
-    set Number of cells       = 8
+    set Number of cells       = 64
     set Point 1               = -10.
     set Point 2               = 10.
     subsection Boundary conditions
@@ -32,7 +32,7 @@ subsection VFP
   end
   subsection Time stepping
     set Final time     = 20.
-    set Method         = FE
+    set Method         = CN
     set Time step size = 0.01
   end
   subsection TransportOnly

--- a/tests/convergence-study/parameter-ERK4.prm
+++ b/tests/convergence-study/parameter-ERK4.prm
@@ -4,7 +4,7 @@ subsection Output
   set Number of digits for counter = 5
   set Output frequency             = 20
   set Results folder               = ./results
-  set Simulation identifier        = convergence-study
+  set Simulation identifier        = convergence-study-ERK4
 end
 subsection Physical parameters
   set B0/2pi = 1.
@@ -18,7 +18,7 @@ subsection VFP
   end
   subsection Mesh
     set Grid type             = Hypercube
-    set Number of cells       = 8
+    set Number of cells       = 64
     set Point 1               = -10.
     set Point 2               = 10.
     subsection Boundary conditions
@@ -32,7 +32,7 @@ subsection VFP
   end
   subsection Time stepping
     set Final time     = 20.
-    set Method         = FE
+    set Method         = ERK4
     set Time step size = 0.01
   end
   subsection TransportOnly

--- a/tests/convergence-study/parameter-FE.prm
+++ b/tests/convergence-study/parameter-FE.prm
@@ -4,7 +4,7 @@ subsection Output
   set Number of digits for counter = 5
   set Output frequency             = 20
   set Results folder               = ./results
-  set Simulation identifier        = convergence-study
+  set Simulation identifier        = convergence-study-FE
 end
 subsection Physical parameters
   set B0/2pi = 1.
@@ -18,7 +18,7 @@ subsection VFP
   end
   subsection Mesh
     set Grid type             = Hypercube
-    set Number of cells       = 8
+    set Number of cells       = 64
     set Point 1               = -10.
     set Point 2               = 10.
     subsection Boundary conditions

--- a/tests/convergence-study/parameter-LSERK.prm
+++ b/tests/convergence-study/parameter-LSERK.prm
@@ -4,7 +4,7 @@ subsection Output
   set Number of digits for counter = 5
   set Output frequency             = 20
   set Results folder               = ./results
-  set Simulation identifier        = convergence-study
+  set Simulation identifier        = convergence-study-LSERK
 end
 subsection Physical parameters
   set B0/2pi = 1.
@@ -18,7 +18,7 @@ subsection VFP
   end
   subsection Mesh
     set Grid type             = Hypercube
-    set Number of cells       = 8
+    set Number of cells       = 64
     set Point 1               = -10.
     set Point 2               = 10.
     subsection Boundary conditions
@@ -32,7 +32,7 @@ subsection VFP
   end
   subsection Time stepping
     set Final time     = 20.
-    set Method         = FE
+    set Method         = LSERK
     set Time step size = 0.01
   end
   subsection TransportOnly

--- a/tests/convergence-study/test-convergence-study.cpp
+++ b/tests/convergence-study/test-convergence-study.cpp
@@ -1,0 +1,357 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2023 by the Sapphire++ authors
+//
+// This file is part of Sapphire++.
+//
+// Sapphire++ is free software: you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version.
+//
+// Sapphire++ is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+// A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+// details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sapphire++. If not, see <https://www.gnu.org/licenses/>.
+//
+// -----------------------------------------------------------------------------
+
+/**
+ * @file tests/convergence-study/test-convergence-study.cpp
+ * @author Florian Schulze (florian.schulze@mpi-hd.mpg.de)
+ * @brief Implement tests for convergence-study example
+ */
+
+#include <deal.II/base/discrete_time.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/parameter_handler.h>
+
+#include <mpi.h>
+
+#include <fstream>
+#include <iostream>
+
+#include "config.h"
+#include "output-parameters.h"
+#include "sapphirepp-logstream.h"
+#include "vfp-parameters.h"
+#include "vfp-solver.h"
+
+
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      /** [Main function setup] */
+      using namespace sapphirepp;
+      using namespace VFP;
+      dealii::Utilities::MPI::MPI_InitFinalize mpi_initialization(argc,
+                                                                  argv,
+                                                                  1);
+
+      saplog.init(2);
+
+      std::string parameter_filename = "parameter.prm";
+      if (argc > 1)
+        parameter_filename = argv[1];
+
+      double max_L2_error = 1e-10;
+      if (argc > 2)
+        max_L2_error = std::stod(argv[2]);
+
+      dealii::ParameterHandler prm;
+      PhysicalParameters       physical_parameters;
+      Utils::OutputParameters  output_parameters;
+      VFPParameters<dimension> vfp_parameters;
+
+      physical_parameters.declare_parameters(prm);
+      output_parameters.declare_parameters(prm);
+      vfp_parameters.declare_parameters(prm);
+
+      prm.parse_input(parameter_filename);
+
+      physical_parameters.parse_parameters(prm);
+      output_parameters.parse_parameters(prm);
+      vfp_parameters.parse_parameters(prm);
+      /** [Main function setup] */
+
+
+      /** [Copy VFP parameter] */
+      physical_parameters.box_length =
+        std::abs(vfp_parameters.p1[0] - vfp_parameters.p2[0]);
+      physical_parameters.velocity = vfp_parameters.velocity;
+      physical_parameters.gamma    = vfp_parameters.gamma;
+      physical_parameters.charge   = vfp_parameters.charge;
+      physical_parameters.mass     = vfp_parameters.mass;
+
+      AssertThrow(dimension == 1,
+                  dealii::ExcMessage("This example assumes 'dimension = 1'."));
+      AssertThrow(vfp_parameters.expansion_order == 1,
+                  dealii::ExcMessage(
+                    "This example assumes 'Expansion order = 1'."));
+      AssertThrow((vfp_parameters.boundary_conditions[0] ==
+                   VFP::BoundaryConditions::periodic) &&
+                    (vfp_parameters.boundary_conditions[1] ==
+                     VFP::BoundaryConditions::periodic),
+                  dealii::ExcMessage("This example assumes periodic BC."));
+      /** [Copy VFP parameter] */
+
+
+      /** [Create error file] */
+      std::ofstream error_file(output_parameters.output_path / "error.csv");
+      AssertThrow(!error_file.fail(),
+                  dealii::ExcFileNotOpen(output_parameters.output_path /
+                                         "error.csv"));
+      error_file << "timestep"
+                 << "; "
+                 << "time"
+                 << "; "
+                 << "L2_norm"
+                 << "; "
+                 << "L2_error"
+                 << "; "
+                 << "relative_error" << std::endl;
+      /** [Create error file] */
+
+
+      /** [Setup vfp_solver] */
+      VFPSolver<dimension> vfp_solver(vfp_parameters,
+                                      physical_parameters,
+                                      output_parameters);
+      vfp_solver.setup();
+      /** [Setup vfp_solver] */
+
+
+      /** [Setup analytic solution] */
+      const unsigned int system_size = vfp_solver.get_pde_system().system_size;
+
+      InitialValueFunction<dimension> analytic_solution(physical_parameters,
+                                                        system_size);
+      const dealii::ComponentSelectFunction<dimension> weight(0, system_size);
+
+      PETScWrappers::MPI::Vector analytic_solution_vector;
+      analytic_solution_vector.reinit(
+        vfp_solver.get_dof_handler().locally_owned_dofs(), MPI_COMM_WORLD);
+      /** [Setup analytic solution] */
+
+
+      /** [Time loop] */
+      DiscreteTime discrete_time(0,
+                                 vfp_parameters.final_time,
+                                 vfp_parameters.time_step);
+      for (; discrete_time.is_at_end() == false; discrete_time.advance_time())
+        {
+          {
+            saplog << "Time step " << std::setw(6) << std::right
+                   << discrete_time.get_step_number()
+                   << " at t = " << discrete_time.get_current_time() << " \t["
+                   << Utilities::System::get_time() << "]" << std::endl;
+
+            analytic_solution.set_time(discrete_time.get_current_time());
+            /** [Time loop] */
+
+
+            /** [Output solution] */
+            if ((discrete_time.get_step_number() %
+                 output_parameters.output_frequency) == 0)
+              {
+                LogStream::Prefix prefix("Output", saplog);
+                saplog << "Output solution" << std::endl;
+
+                dealii::DataOut<dimension> data_out;
+                data_out.attach_dof_handler(vfp_solver.get_dof_handler());
+
+                // Output numeric solution
+                data_out.add_data_vector(vfp_solver.get_current_solution(),
+                                         PDESystem::create_component_name_list(
+                                           system_size));
+
+                // Output projected analytic solution
+                vfp_solver.project(analytic_solution, analytic_solution_vector);
+                data_out.add_data_vector(analytic_solution_vector,
+                                         PDESystem::create_component_name_list(
+                                           system_size, "project_f_"));
+
+                // Output interpolated analytic solution
+                dealii::VectorTools::interpolate(vfp_solver.get_dof_handler(),
+                                                 analytic_solution,
+                                                 analytic_solution_vector);
+                data_out.add_data_vector(analytic_solution_vector,
+                                         PDESystem::create_component_name_list(
+                                           system_size, "interpol_f_"));
+
+                data_out.build_patches(vfp_parameters.polynomial_degree);
+                output_parameters.write_results<dimension>(
+                  data_out,
+                  discrete_time.get_step_number(),
+                  discrete_time.get_current_time());
+              }
+            /** [Output solution] */
+
+
+            /** [Calculate error] */
+            {
+              LogStream::Prefix prefix2("Error", saplog);
+              saplog << "Calculate error" << std::endl;
+
+              const double L2_error =
+                vfp_solver.compute_global_error(analytic_solution,
+                                                dealii::VectorTools::L2_norm,
+                                                dealii::VectorTools::L2_norm,
+                                                &weight);
+              const double L2_norm =
+                vfp_solver.compute_weighted_norm(dealii::VectorTools::L2_norm,
+                                                 dealii::VectorTools::L2_norm,
+                                                 &weight);
+
+              saplog << "L2_error = " << L2_error << ", L2_norm = " << L2_norm
+                     << ", rel error = " << L2_error / L2_norm << std::endl;
+
+              error_file << discrete_time.get_step_number() << "; "
+                         << discrete_time.get_current_time() << "; " << L2_norm
+                         << "; " << L2_error << "; " << L2_error / L2_norm
+                         << std::endl;
+
+              AssertThrow((L2_error / L2_norm) < max_L2_error,
+                          dealii::ExcMessage(
+                            "L2 error is too large! (" +
+                            dealii::Utilities::to_string(L2_error / L2_norm) +
+                            " > " + dealii::Utilities::to_string(max_L2_error) +
+                            ")"));
+            }
+            /** [Calculate error] */
+
+
+            /** [Time step] */
+            switch (vfp_parameters.time_stepping_method)
+              {
+                case TimeSteppingMethod::forward_euler:
+                case TimeSteppingMethod::backward_euler:
+                case TimeSteppingMethod::crank_nicolson:
+                  vfp_solver.theta_method(discrete_time.get_current_time(),
+                                          discrete_time.get_next_step_size());
+                  break;
+                case TimeSteppingMethod::erk4:
+                  vfp_solver.explicit_runge_kutta(
+                    discrete_time.get_current_time(),
+                    discrete_time.get_next_step_size());
+                  break;
+                case TimeSteppingMethod::lserk:
+                  vfp_solver.low_storage_explicit_runge_kutta(
+                    discrete_time.get_current_time(),
+                    discrete_time.get_next_step_size());
+                  break;
+                default:
+                  AssertThrow(false, ExcNotImplemented());
+              }
+          }
+        }
+      /** [Time step] */
+
+
+      /** [Last time step] */
+      analytic_solution.set_time(discrete_time.get_current_time());
+
+      {
+        LogStream::Prefix prefix("Output", saplog);
+        saplog << "Output results" << std::endl;
+
+        dealii::DataOut<dimension> data_out;
+        data_out.attach_dof_handler(vfp_solver.get_dof_handler());
+
+        // Output numeric solution
+        data_out.add_data_vector(vfp_solver.get_current_solution(),
+                                 PDESystem::create_component_name_list(
+                                   system_size));
+
+        // Output projected analytic solution
+        vfp_solver.project(analytic_solution, analytic_solution_vector);
+        data_out.add_data_vector(
+          analytic_solution_vector,
+          PDESystem::create_component_name_list(system_size, "project_f_"));
+
+        // Output interpolated analytic solution
+        dealii::VectorTools::interpolate(vfp_solver.get_dof_handler(),
+                                         analytic_solution,
+                                         analytic_solution_vector);
+        data_out.add_data_vector(
+          analytic_solution_vector,
+          PDESystem::create_component_name_list(system_size, "interpol_f_"));
+
+        data_out.build_patches(vfp_parameters.polynomial_degree);
+        output_parameters.write_results<dimension>(
+          data_out,
+          discrete_time.get_step_number(),
+          discrete_time.get_current_time());
+      }
+
+      {
+        LogStream::Prefix prefix2("Error", saplog);
+        saplog << "Calculate L2 error" << std::endl;
+
+        const double L2_error =
+          vfp_solver.compute_global_error(analytic_solution,
+                                          dealii::VectorTools::L2_norm,
+                                          dealii::VectorTools::L2_norm,
+                                          &weight);
+        const double L2_norm =
+          vfp_solver.compute_weighted_norm(dealii::VectorTools::L2_norm,
+                                           dealii::VectorTools::L2_norm,
+                                           &weight);
+
+        saplog << "L2_error = " << L2_error << ", L2_norm = " << L2_norm
+               << ", rel error = " << L2_error / L2_norm << std::endl;
+
+        error_file << discrete_time.get_step_number() << "; "
+                   << discrete_time.get_current_time() << "; " << L2_norm
+                   << "; " << L2_error << "; " << L2_error / L2_norm
+                   << std::endl;
+
+        AssertThrow((L2_error / L2_norm) < max_L2_error,
+                    dealii::ExcMessage(
+                      "L2 error is too large! (" +
+                      dealii::Utilities::to_string(L2_error / L2_norm) + " > " +
+                      dealii::Utilities::to_string(max_L2_error) + ")"));
+      }
+      /** [Last time step] */
+
+
+      /** [End simulation] */
+      saplog << "Simulation ended at t = " << discrete_time.get_current_time()
+             << " \t[" << Utilities::System::get_time() << "]" << std::endl;
+
+      error_file.close();
+      /** [End simulation] */
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  return 0;
+}

--- a/tests/gyro-advection/CMakeLists.txt
+++ b/tests/gyro-advection/CMakeLists.txt
@@ -14,7 +14,7 @@ add_test(NAME gyro-advection
 set_property(TEST gyro-advection PROPERTY
              LABELS "gyro-advection"
                     "2d" "spatial_advection" "magnetic"
-                    "Crank-Nicholson" "periodic BC"
+                    "CN" "periodic BC"
                     "commit-Release" "commit-Debug"
                     "full-suite-Release" "full-suite-Debug")
 
@@ -23,7 +23,7 @@ add_test(NAME gyro-static
 set_property(TEST gyro-static PROPERTY
              LABELS "gyro-advection"
                     "2d" "spatial_advection" "magnetic"
-                    "Crank-Nicholson" "continuos gradients"
+                    "CN" "continuos gradients"
                     "commit-Release" "commit-Debug"
                     "full-suite-Release" "full-suite-Debug")
 

--- a/tests/gyro-advection/test-gyro-advection.cpp
+++ b/tests/gyro-advection/test-gyro-advection.cpp
@@ -115,12 +115,10 @@ main(int argc, char *argv[])
 
       saplog << "Calculate analytic solution" << std::endl;
       InitialValueFunction<dimension> analytic_solution(
-        physical_parameters, vfp_parameters.expansion_order);
+        physical_parameters, vfp_solver.get_pde_system().system_size);
 
       const dealii::ComponentSelectFunction<dimension> weight(
-        0,
-        (vfp_parameters.expansion_order + 1) *
-          (vfp_parameters.expansion_order + 1));
+        0, vfp_solver.get_pde_system().system_size);
 
       const double L2_error =
         vfp_solver.compute_global_error(analytic_solution,

--- a/tests/parallel-shock/CMakeLists.txt
+++ b/tests/parallel-shock/CMakeLists.txt
@@ -14,7 +14,7 @@ add_test(NAME parallel-shock
 set_property(TEST parallel-shock PROPERTY
              LABELS "parallel-shock"
                     "2d" "momentum" "spatial_advection" "source" "scattering"
-                    "shock" "Crank-Nicholson" "mpi"
+                    "shock" "CN" "mpi"
                     "commit-Release"
                     "full-suite-Release" "full-suite-Debug")
 

--- a/tests/parallel-shock/test-parallel-shock.cpp
+++ b/tests/parallel-shock/test-parallel-shock.cpp
@@ -49,11 +49,11 @@ namespace sapinternal
     {
     public:
       AnalyticSolution(const PhysicalParameters &physical_parameters,
-                       const unsigned int        exp_order,
+                       const unsigned int        system_size,
                        const double             &mass)
-        : Function<dim>((exp_order + 1) * (exp_order + 1))
+        : Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{VFP::PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{VFP::PDESystem::create_lms_indices(system_size)}
         , particle_velocity(mass)
         , scattering_frequency(prm)
       {}
@@ -108,10 +108,10 @@ namespace sapinternal
     {
     public:
       WeightFunction(const PhysicalParameters &physical_parameters,
-                     const unsigned int        exp_order)
-        : Function<dim>((exp_order + 1) * (exp_order + 1))
+                     const unsigned int        system_size)
+        : Function<dim>(system_size)
         , prm{physical_parameters}
-        , lms_indices{VFP::PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{VFP::PDESystem::create_lms_indices(system_size)}
       {}
 
 
@@ -197,7 +197,7 @@ main(int argc, char *argv[])
 
       AnalyticSolution<dimension> analytic_solution(
         physical_parameters,
-        vfp_parameters.expansion_order,
+        vfp_solver.get_pde_system().system_size,
         vfp_parameters.mass);
 
       WeightFunction<dimension> weight(physical_parameters,

--- a/tests/scattering-only/CMakeLists.txt
+++ b/tests/scattering-only/CMakeLists.txt
@@ -17,7 +17,7 @@ add_test(NAME scattering-only-1d-CN
 set_property(TEST scattering-only-1d-CN PROPERTY
              LABELS "scattering-only"
                     "1d" "scattering"
-                    "Crank-Nicholson" "periodic BC"
+                    "CN" "periodic BC"
                     "full-suite-Release" "full-suite-Debug")
 
 add_test(NAME scattering-only-1d-ERK4
@@ -34,7 +34,8 @@ set_property(TEST scattering-only-1d-ERK4 PROPERTY
 # set_property(TEST scattering-only-1d-LSERK PROPERTY
 #              LABELS "scattering-only"
 #                     "1d" "scattering"
-#                     "LSERK" "periodic BC")
+#                     "LSERK" "periodic BC"
+#                     "full-suite-Debug" "full-suite-Release")
 
 add_test(NAME scattering-only-1d-FE
          COMMAND ./test-scattering-only-1d parameter-1d-FE.prm test_run 1e-1)

--- a/tests/scattering-only/test-scattering-only-1d.cpp
+++ b/tests/scattering-only/test-scattering-only-1d.cpp
@@ -52,11 +52,11 @@ namespace sapinternal
     {
     public:
       AnalyticSolution(const PhysicalParameters &physical_parameters,
-                       const unsigned int        exp_order,
+                       const unsigned int        system_size,
                        const double              time)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1), time)
+        : dealii::Function<dim>(system_size, time)
         , prm{physical_parameters}
-        , lms_indices{VFP::PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{VFP::PDESystem::create_lms_indices(system_size)}
       {}
 
 
@@ -144,7 +144,7 @@ convergence_with_expansion_order(const std::string         &parameter_filename,
       using namespace sapinternal::AnalyticSolutionImplementation;
       AnalyticSolution<dimension> analytic_solution(
         physical_parameters,
-        vfp_parameters.expansion_order,
+        vfp_solver.get_pde_system().system_size,
         vfp_parameters.final_time);
 
       const double L2_error =
@@ -202,9 +202,10 @@ test_run(const std::string &parameter_filename, const double max_L2_error)
   timer.stop();
 
   using namespace sapinternal::AnalyticSolutionImplementation;
-  AnalyticSolution<dimension> analytic_solution(physical_parameters,
-                                                vfp_parameters.expansion_order,
-                                                vfp_parameters.final_time);
+  AnalyticSolution<dimension> analytic_solution(
+    physical_parameters,
+    vfp_solver.get_pde_system().system_size,
+    vfp_parameters.final_time);
 
   const double L2_error =
     vfp_solver.compute_global_error(analytic_solution,

--- a/tests/scattering-only/test-scattering-only-2d.cpp
+++ b/tests/scattering-only/test-scattering-only-2d.cpp
@@ -52,11 +52,11 @@ namespace sapinternal
     {
     public:
       AnalyticSolution(const PhysicalParameters &physical_parameters,
-                       const unsigned int        exp_order,
+                       const unsigned int        system_size,
                        const double              time)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1), time)
+        : dealii::Function<dim>(system_size, time)
         , prm{physical_parameters}
-        , lms_indices{VFP::PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{VFP::PDESystem::create_lms_indices(system_size)}
       {}
 
 
@@ -137,9 +137,10 @@ main(int argc, char *argv[])
       timer.stop();
 
       using namespace sapinternal::AnalyticSolutionImplementation;
-      AnalyticSolution<dim> analytic_solution(physical_parameters,
-                                              vfp_parameters.expansion_order,
-                                              vfp_parameters.final_time);
+      AnalyticSolution<dim> analytic_solution(
+        physical_parameters,
+        vfp_solver.get_pde_system().system_size,
+        vfp_parameters.final_time);
 
       const double L2_error =
         vfp_solver.compute_global_error(analytic_solution,

--- a/tests/scattering-only/test-scattering-only-3d.cpp
+++ b/tests/scattering-only/test-scattering-only-3d.cpp
@@ -52,11 +52,11 @@ namespace sapinternal
     {
     public:
       AnalyticSolution(const PhysicalParameters &physical_parameters,
-                       const unsigned int        exp_order,
+                       const unsigned int        system_size,
                        const double              time)
-        : dealii::Function<dim>((exp_order + 1) * (exp_order + 1), time)
+        : dealii::Function<dim>(system_size, time)
         , prm{physical_parameters}
-        , lms_indices{VFP::PDESystem::create_lms_indices(exp_order)}
+        , lms_indices{VFP::PDESystem::create_lms_indices(system_size)}
       {}
 
 
@@ -136,9 +136,10 @@ main(int argc, char *argv[])
       timer.stop();
 
       using namespace sapinternal::AnalyticSolutionImplementation;
-      AnalyticSolution<dim> analytic_solution(physical_parameters,
-                                              vfp_parameters.expansion_order,
-                                              vfp_parameters.final_time);
+      AnalyticSolution<dim> analytic_solution(
+        physical_parameters,
+        vfp_solver.get_pde_system().system_size,
+        vfp_parameters.final_time);
 
       const double L2_error =
         vfp_solver.compute_global_error(analytic_solution,


### PR DESCRIPTION
Adds "convergence-study" example with documentation and tests. In addition the "visualization" section is rewritten. Some changes where made to the VFP module, indluding:

- Consistently use pde_system.system_size instead of expansion order in all instances of the code. This will allow to easily change the order/number of exapnsion coefficients used. E.g. use only m=-1,0,1 for l=1,2,3,4,5...
- Add convenience function `create_component_name_list` (for `lms` components)
- Output results at the *start* of a time step, instead of the end. (Allows for slightly easier parsing)