### PR TITLE
fix(vfp-solver): remove spurious static specifier in config.h

### DIFF
--- a/examples/vfp/closure/config.h
+++ b/examples/vfp/closure/config.h
@@ -107,16 +107,16 @@ namespace sapphirepp
   {
     /** [Dimension] */
     /** Specify reduced phase space dimension \f$ (\mathbf{x}, p) \f$ */
-    static constexpr unsigned int dimension = 1;
+    constexpr unsigned int dimension = 1;
     /** [Dimension] */
 
 
 
     /** [VFP Flags] */
     /** Specify which terms of the VFP equation should be active */
-    static constexpr VFPFlags vfp_flags = VFPFlags::time_evolution |
-                                          VFPFlags::spatial_advection |
-                                          VFPFlags::time_independent_fields;
+    constexpr VFPFlags vfp_flags = VFPFlags::time_evolution |
+                                   VFPFlags::spatial_advection |
+                                   VFPFlags::time_independent_fields;
     /** [VFP Flags] */
 
 

--- a/examples/vfp/convergence-study/config.h
+++ b/examples/vfp/convergence-study/config.h
@@ -106,14 +106,14 @@ namespace sapphirepp
   {
     /** [Dimension] */
     /** Specify reduced phase space dimension \f$ (\mathbf{x}, p) \f$ */
-    static constexpr unsigned int dimension = 1;
+    constexpr unsigned int dimension = 1;
     /** [Dimension] */
 
 
 
     /** [VFP Flags] */
     /** Specify which terms of the VFP equation should be active */
-    static constexpr VFPFlags vfp_flags =
+    constexpr VFPFlags vfp_flags =
       VFPFlags::time_evolution | VFPFlags::spatial_advection |
       VFPFlags::rotation | VFPFlags::time_independent_fields;
     /** [VFP Flags] */

--- a/examples/vfp/gyro-advection/config.h
+++ b/examples/vfp/gyro-advection/config.h
@@ -111,14 +111,14 @@ namespace sapphirepp
   {
     /** [Dimension] */
     /** Specify reduced phase space dimension \f$ (\mathbf{x}, p) \f$ */
-    static constexpr unsigned int dimension = 2;
+    constexpr unsigned int dimension = 2;
     /** [Dimension] */
 
 
 
     /** [VFP Flags] */
     /** Specify which terms of the VFP equation should be active */
-    static constexpr VFPFlags vfp_flags =
+    constexpr VFPFlags vfp_flags =
       VFPFlags::time_evolution | VFPFlags::spatial_advection |
       VFPFlags::rotation | VFPFlags::time_independent_fields;
     /** [VFP Flags] */

--- a/examples/vfp/parallel-shock/config.h
+++ b/examples/vfp/parallel-shock/config.h
@@ -163,14 +163,14 @@ namespace sapphirepp
   {
     /** [Dimension] */
     /** Specify reduced phase space dimension \f$ (\mathbf{x}, p) \f$ */
-    static constexpr unsigned int dimension = 2;
+    constexpr unsigned int dimension = 2;
     /** [Dimension] */
 
 
 
     /** [VFP Flags] */
     /** Specify which terms of the VFP equation should be active */
-    static constexpr VFPFlags vfp_flags =
+    constexpr VFPFlags vfp_flags =
       VFPFlags::time_evolution | VFPFlags::spatial_advection |
       VFPFlags::momentum | VFPFlags::collision | VFPFlags::rotation |
       VFPFlags::source | VFPFlags::time_independent_fields |

--- a/examples/vfp/scattering-only/config.h
+++ b/examples/vfp/scattering-only/config.h
@@ -111,7 +111,7 @@ namespace sapphirepp
     /** [Dimension] */
     // !!!EDIT HERE!!!
     /** Specify reduced phase space dimension \f$ (\mathbf{x}, p) \f$ */
-    static constexpr unsigned int dimension = 1;
+    constexpr unsigned int dimension = 1;
     /** [Dimension] */
 
 
@@ -119,7 +119,7 @@ namespace sapphirepp
     /** [VFP Flags] */
     // !!!EDIT HERE!!!
     /** Specify which terms of the VFP equation should be active */
-    static constexpr VFPFlags vfp_flags =
+    constexpr VFPFlags vfp_flags =
       VFPFlags::time_evolution | VFPFlags::collision;
     /** [VFP Flags] */
 

--- a/examples/vfp/steady-state-parallel-shock/config.h
+++ b/examples/vfp/steady-state-parallel-shock/config.h
@@ -163,16 +163,16 @@ namespace sapphirepp
   {
     /** [Dimension] */
     /** Specify reduced phase space dimension \f$ (\mathbf{x}, p) \f$ */
-    static constexpr unsigned int dimension = 2;
+    constexpr unsigned int dimension = 2;
     /** [Dimension] */
 
 
 
     /** [VFP Flags] */
     /** Specify which terms of the VFP equation should be active */
-    static constexpr VFPFlags vfp_flags =
-      VFPFlags::spatial_advection | VFPFlags::momentum | VFPFlags::collision |
-      VFPFlags::rotation | VFPFlags::source;
+    constexpr VFPFlags vfp_flags = VFPFlags::spatial_advection |
+                                   VFPFlags::momentum | VFPFlags::collision |
+                                   VFPFlags::rotation | VFPFlags::source;
     /** [VFP Flags] */
 
 

--- a/examples/vfp/steady-state-parallel-shock/scaled/config.h
+++ b/examples/vfp/steady-state-parallel-shock/scaled/config.h
@@ -164,17 +164,17 @@ namespace sapphirepp
   {
     /** [Dimension] */
     /** Specify reduced phase space dimension \f$ (\mathbf{x}, p) \f$ */
-    static constexpr unsigned int dimension = 2;
+    constexpr unsigned int dimension = 2;
     /** [Dimension] */
 
 
 
     /** [VFP Flags] */
     /** Specify which terms of the VFP equation should be active */
-    static constexpr VFPFlags vfp_flags =
-      VFPFlags::spatial_advection | VFPFlags::momentum | VFPFlags::collision |
-      VFPFlags::rotation | VFPFlags::source |
-      VFPFlags::scaled_distribution_function;
+    constexpr VFPFlags vfp_flags = VFPFlags::spatial_advection |
+                                   VFPFlags::momentum | VFPFlags::collision |
+                                   VFPFlags::rotation | VFPFlags::source |
+                                   VFPFlags::scaled_distribution_function;
     /** [VFP Flags] */
 
 

--- a/include/config.h
+++ b/include/config.h
@@ -114,7 +114,7 @@ namespace sapphirepp
     /** [Dimension] */
     // !!!EDIT HERE!!!
     /** Specify reduced phase space dimension \f$ (\mathbf{x}, p) \f$ */
-    static constexpr unsigned int dimension = 2;
+    constexpr unsigned int dimension = 2;
     /** [Dimension] */
 
 
@@ -122,7 +122,7 @@ namespace sapphirepp
     /** [VFP Flags] */
     // !!!EDIT HERE!!!
     /** Specify which terms of the VFP equation should be active */
-    static constexpr VFPFlags vfp_flags =
+    constexpr VFPFlags vfp_flags =
       VFPFlags::time_evolution | VFPFlags::spatial_advection |
       VFPFlags::momentum | VFPFlags::collision | VFPFlags::source |
       VFPFlags::time_independent_fields | VFPFlags::time_independent_source;


### PR DESCRIPTION
We noted that we use unnecessarily the `static` specifier for some variables in our config.h files.
This PR removes them